### PR TITLE
Fixes line height for the custom font

### DIFF
--- a/apps/dapp/src/style/index.css
+++ b/apps/dapp/src/style/index.css
@@ -4,24 +4,28 @@
   font-family: Ilisarniq;
   src: url('/fonts/Ilisarniq-Light.otf');
   font-weight: 300;
+  ascent-override: 90%;
 }
 
 @font-face {
   font-family: Ilisarniq;
   src: url('/fonts/Ilisarniq-Regular.otf');
   font-weight: 400;
+  ascent-override: 90%;
 }
 
 @font-face {
   font-family: Ilisarniq;
   src: url('/fonts/Ilisarniq-Demi.otf');
   font-weight: 500;
+  ascent-override: 90%;
 }
 
 @font-face {
   font-family: Ilisarniq;
   src: url('/fonts/Ilisarniq-Bold.otf');
   font-weight: 700;
+  ascent-override: 90%;
 }
 
 @font-face {


### PR DESCRIPTION
Notice the different spacing above and below text getting fixed: 

Before
<img width="100" alt="image" src="https://user-images.githubusercontent.com/6696080/227917358-712d936f-5171-4b2c-af06-79853c4b7a14.png">


After
<img width="100" alt="image" src="https://user-images.githubusercontent.com/6696080/227917307-0528c327-5585-4a72-a0ef-c49ba06cb8da.png">


