### PR TITLE
refactor: lodash imports

### DIFF
--- a/apps/dapp/src/components/olp/OlpHome/index.tsx
+++ b/apps/dapp/src/components/olp/OlpHome/index.tsx
@@ -13,8 +13,8 @@ import {
   TableRow,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import _ from 'lodash';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import sortBy from 'lodash/sortBy';
 import { IOlpApi } from 'pages/olp';
 
 import { TablePaginationActions, Typography } from 'components/UI';
@@ -97,7 +97,7 @@ export const OlpHome = ({ olps }: { olps: Record<string, IOlpApi[]> }) => {
 
     if (!expiries) return [];
 
-    return _.sortBy(expiries)?.map((o) => getReadableTime(o!));
+    return sortBy(expiries)?.map((o) => getReadableTime(o!));
   }, [olps, chainIds]);
 
   const olpNetworks = useMemo(() => {

--- a/apps/dapp/src/components/olp/Stats/index.tsx
+++ b/apps/dapp/src/components/olp/Stats/index.tsx
@@ -7,7 +7,7 @@ import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import { zipWith } from 'lodash';
+import zipWith from 'lodash/zipWith';
 import { useBoundStore } from 'store';
 
 import Typography from 'components/UI/Typography';

--- a/apps/dapp/src/store/Vault/olp/index.ts
+++ b/apps/dapp/src/store/Vault/olp/index.ts
@@ -1,6 +1,6 @@
 import { StateCreator } from 'zustand';
 import { BigNumber } from 'ethers';
-import { orderBy } from 'lodash';
+import orderBy from 'lodash/orderBy';
 import { SsovLp, SsovLp__factory, Addresses } from '@dopex-io/sdk';
 
 import { WalletSlice } from 'store/Wallet';


### PR DESCRIPTION
Reduces page sizes by around 10 to 20 kb

Before:
<img width="625" alt="Screenshot 2023-04-01 at 6 45 56 AM" src="https://user-images.githubusercontent.com/79846912/229262372-b965bb44-2f31-4372-b9f2-7d889dfc8c01.png">

After:
<img width="614" alt="Screenshot 2023-04-01 at 6 46 51 AM" src="https://user-images.githubusercontent.com/79846912/229262383-9ea8fbb1-8fe6-411a-ae8e-47955d921adc.png">
