### PR TITLE
fix: scalps pnl % (DOP-365)

### DIFF
--- a/apps/dapp/src/components/scalps/Positions/PositionsTable.tsx
+++ b/apps/dapp/src/components/scalps/Positions/PositionsTable.tsx
@@ -277,11 +277,11 @@ const PositionsTable = ({ tab }: { tab: string }) => {
             <span>{`${formatAmount(data.toFixed(4), 2)} (${formatAmount(
               (position.pnl /
                 getUserReadableAmount(
-                  position.margin,
+                  position.margin.add(position.premium).add(position.fees),
                   optionScalpData?.quoteDecimals.toNumber()
                 )) *
                 100,
-              1
+              2
             )}%)`}</span>
           </Tooltip>
         );


### PR DESCRIPTION
## Scope

Implementing revised pnl % formula

[closes issue-365](https://linear.app/dopex/issue/DOP-365/option-scalps-pnl-percent-is-broken)

## Implementation

With @0xYYC we have decided to change the formula from

pnl / margin

to

pnl / (margin + fees + premium)

I've also changed the decimals used from 1 to 2

## Screenshots

Not required

## How to Test

Open /scalps/ETH and check your closed positions PNLs
