### PR TITLE
fix: pnl % share card

### DIFF
--- a/apps/dapp/src/components/scalps/Positions/PositionsTable.tsx
+++ b/apps/dapp/src/components/scalps/Positions/PositionsTable.tsx
@@ -48,8 +48,17 @@ const PositionsTable = ({ tab }: { tab: string }) => {
     (position: any) => {
       if (!optionScalpData) return;
 
-      const { entry, pnl, margin, size, isShort, closePrice, isOpen } =
-        position;
+      const {
+        entry,
+        pnl,
+        margin,
+        size,
+        isShort,
+        closePrice,
+        isOpen,
+        premium,
+        fees,
+      } = position;
 
       const leverage =
         size /
@@ -83,7 +92,7 @@ const PositionsTable = ({ tab }: { tab: string }) => {
         percentage:
           (pnl /
             getUserReadableAmount(
-              margin,
+              margin.add(premium).add(fees),
               optionScalpData?.quoteDecimals.toNumber()
             )) *
           100,


### PR DESCRIPTION
## Scope

Update the handleShare() function of PositionsTable.tsx so the % pnl of the shareable card is the same of the one displayed in the table

[closes issue-373](https://linear.app/dopex/issue/DOP-373/option-scalps-share-card-percent-pnl-doesnt-match-with-table-pnl)

## Implementation

I copied the code used for the table.
What happens now is that fees and premium are added to margin.

## Screenshots
None

## How to Test
Go to an option scalps vault and check your closed positions
