### PR TITLE
fix: scalps deposits/withdrawing max amount round issues (DOP-374)

### DIFF
--- a/apps/dapp/src/components/scalps/DepositCard/index.tsx
+++ b/apps/dapp/src/components/scalps/DepositCard/index.tsx
@@ -77,6 +77,12 @@ const DepositCard = () => {
     );
   }, [optionScalpData, userTokenBalance, isQuote]);
 
+  const handleSetMax = useCallback(() => {
+    setRawAmount(
+      String(Math.floor(readableUserTokenBalance * 100000) / 100000)
+    ); // 5 decimals
+  }, [readableUserTokenBalance]);
+
   const updateUserBalance = useCallback(async () => {
     if (!accountAddress || !provider) return;
     const balance = await ERC20__factory.connect(
@@ -327,9 +333,9 @@ const DepositCard = () => {
               variant="h6"
               role="button"
               className="text-stieglitz text-sm pl-1 pr-3 text-[0.8rem] underline"
-              onClick={() => setRawAmount(String(readableUserTokenBalance))}
+              onClick={handleSetMax}
             >
-              {formatAmount(readableUserTokenBalance, isQuote ? 0 : 3)}{' '}
+              {formatAmount(readableUserTokenBalance, 8)}{' '}
               {isQuote
                 ? optionScalpData?.quoteSymbol!
                 : _resolveSymbol(optionScalpData?.baseSymbol!)}

--- a/apps/dapp/src/components/scalps/WithdrawCard/index.tsx
+++ b/apps/dapp/src/components/scalps/WithdrawCard/index.tsx
@@ -70,6 +70,12 @@ const WithdrawCard = () => {
     );
   }, [optionScalpData, userTokenBalance, isQuote]);
 
+  const handleSetMax = useCallback(() => {
+    setRawAmount(
+      String(Math.floor(readableUserTokenBalance * 100000) / 100000)
+    ); // 5 decimals
+  }, [readableUserTokenBalance]);
+
   const withdrawButtonProps = useMemo(() => {
     let disabled = false;
     let text: any = 'Withdraw';
@@ -89,7 +95,6 @@ const WithdrawCard = () => {
       text = 'Amount exceeds balance';
       disabled = true;
     }
-
 
     if (isQuote && (optionScalpUserData?.coolingPeriod?.quote ?? 0) > date) {
       coolDown = optionScalpUserData?.coolingPeriod?.quote ?? 0;
@@ -295,7 +300,7 @@ const WithdrawCard = () => {
               variant="h6"
               role="button"
               className="text-stieglitz text-sm pl-1 pr-3 text-[0.8rem] underline"
-              onClick={() => setRawAmount(String(readableUserTokenBalance))}
+              onClick={handleSetMax}
             >
               {formatAmount(readableUserTokenBalance, 8)}{' '}
               {isQuote


### PR DESCRIPTION
## Scope
Some users reported they have issues when trying to max withdraw or deposit.
The issue is that using String() we round up the number if the last digit we support it's above 5.
I propose this solution which uses Math.floor() to round down.

[closes issue-374](https://linear.app/dopex/issue/DOP-374/fix-round-issue-when-max-depositing-or-withdrawing-from-scalps)

## Implementation
Using Math.floor() we can be sure we round down the number

## Screenshots

None

## How to Test
Open demo deployment link and try to max deposit and withdraw