### PR TITLE
fix(atlantics): arbitrum icon

### DIFF
--- a/apps/dapp/src/components/atlantics/InsuredPerps/ManageCard/Swap/index.tsx
+++ b/apps/dapp/src/components/atlantics/InsuredPerps/ManageCard/Swap/index.tsx
@@ -245,7 +245,7 @@ const Swap = (props: SwapProps) => {
                       inverted ? stable.toLowerCase() : underlying.toLowerCase()
                     }.svg`}
                     alt={inverted ? stable : underlying}
-                    className="w-full"
+                    className="w-8"
                   />
                   <Typography variant="h6" className="my-auto">
                     {inverted ? stable : underlying}
@@ -301,7 +301,7 @@ const Swap = (props: SwapProps) => {
                       inverted ? underlying.toLowerCase() : stable.toLowerCase()
                     }.svg`}
                     alt={stable}
-                    className="w-[1.9rem]"
+                    className="w-8"
                   />
                   <Typography variant="h6" className="my-auto">
                     {inverted ? underlying : stable}

--- a/apps/dapp/src/components/atlantics/Manage/ContractData/ExplorerLink.tsx
+++ b/apps/dapp/src/components/atlantics/Manage/ContractData/ExplorerLink.tsx
@@ -26,7 +26,7 @@ const ExplorerLink = (props: ExplorerLinkProps) => {
         className="flex space-x-2 bg-[#2D374B] rounded-lg p-2"
       >
         <img
-          src={CHAINS[chainId]?.explorer}
+          src={`/images/networks/${CHAINS[chainId]?.name.toLowerCase()}.svg`}
           alt={CHAINS[chainId]?.name}
           className="h-[1rem] my-auto"
         />


### PR DESCRIPTION
<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope

<!-- Brief description of WHAT you’re doing and WHY. -->

[closes issue-DOP-368](https://linear.app/dopex/issue/DOP-368/insured-prep-swap-ui-when-swaping-usdc-to-weth)

## Implementation

With @pair

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

|         | before | after |
| ------- | ------ | ----- |
| desktop |        |       |
| mobile  |        |       |

## How to Test

Trade -> Insured Perps -> Swap on right-hand side panel -> click the reverse button for token pair
