### PR TITLE
fix: option scalp invalid first load [DOP-375]

### DIFF
--- a/apps/dapp/src/store/Vault/scalps/index.ts
+++ b/apps/dapp/src/store/Vault/scalps/index.ts
@@ -275,6 +275,8 @@ export const createOptionScalpSlice: StateCreator<
     const quoteLpContract = getOptionScalpsQuoteLpContract();
     const baseLpContract = getOptionScalpsBaseLpContract();
 
+    if (!optionScalpContract) return;
+
     const [
       minimumMargin,
       feeOpenPosition,


### PR DESCRIPTION
The function updateScalpData() uses optionScalp which is null when the page loads.
We should check if that variable exists before to proceed.

## Scope

It is a simple line which checks if optionScalpContract exists or skip the execution of the function

[closes issue-375](https://linear.app/dopex/issue/DOP-375/option-scalp-crashes-at-first-load)

## Implementation
if (!optionScalpContract) return;

## Screenshots
Not available

## How to Test
Open the demo link https://dapp-git-fix-option-scalps-null-option-scalp-contract-dopex-io.vercel.app/scalps/ETH and see if the stats table appears correctly