### PR TITLE
fix: hide 0 rewards from ssov writepositions (DOP-377)

### DIFF
--- a/apps/dapp/src/components/ssov/WritePositions/WritePositionData.tsx
+++ b/apps/dapp/src/components/ssov/WritePositions/WritePositionData.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
-import TableRow from '@mui/material/TableRow';
-import TableCell from '@mui/material/TableCell';
 
-import Typography from 'components/UI/Typography';
+import TableCell from '@mui/material/TableCell';
+import TableRow from '@mui/material/TableRow';
+import { TokenData } from 'types';
 
 import { WritePositionInterface } from 'store/Vault/ssov';
 
-import getUserReadableAmount from 'utils/contracts/getUserReadableAmount';
-import formatAmount from 'utils/general/formatAmount';
-
 import NumberDisplay from 'components/UI/NumberDisplay';
 import SplitButton from 'components/UI/SplitButton';
+import Typography from 'components/UI/Typography';
 
-import { TokenData } from 'types';
+import getUserReadableAmount from 'utils/contracts/getUserReadableAmount';
+import formatAmount from 'utils/general/formatAmount';
 
 interface Props extends WritePositionInterface {
   collateralSymbol: string;
@@ -62,12 +61,12 @@ const WritePositionTableData = (props: Props) => {
       </TableCell>
       <TableCell>
         {accruedRewards.map((rewards, index) => {
-          return (
+          return rewards.gt(0) ? (
             <Typography variant="h6" key={index}>
               <NumberDisplay n={rewards} decimals={18} />{' '}
               {rewardTokens[index]?.symbol}
             </Typography>
-          );
+          ) : null;
         })}
       </TableCell>
       <TableCell>


### PR DESCRIPTION
## Scope

<!-- Brief description of WHAT you’re doing and WHY. -->

[closes issue-DOP-377](https://linear.app/dopex/issue/DOP-377/fix-hide-0-rewards-from-ssov-writepositions)

## Implementation

The function returns the code only if rewards is greater than 0, otherwise it's null

## Screenshots
![Pre](https://i.imgur.com/ZEFeNcV.png)
![Post](https://i.imgur.com/9rI9pEw.png)


## How to Test

Open the demo and check DPX ssov.  You must have a write position.
