### PR TITLE
fix: use Uni V3 instead of GMX for straddles rdpx and dpx routes (DOP-378)

### DIFF
--- a/apps/dapp/src/components/straddles/PurchaseCard/index.tsx
+++ b/apps/dapp/src/components/straddles/PurchaseCard/index.tsx
@@ -37,8 +37,8 @@ import PnlChart from '../PnlChart';
 
 const POOL_TO_SWAPPER_IDS: { [key: string]: number[] } = {
   ETH: [2, 3],
-  DPX: [5, 6],
-  RDPX: [5, 6],
+  DPX: [6, 6],
+  RDPX: [6, 6],
   MATIC: [2, 3],
 };
 


### PR DESCRIPTION
## Scope

<!-- Brief description of WHAT you’re doing and WHY. -->

It's not possible to buy ETH with USDC using GMX right now.
With this PR I update the paths of DPX and RDPX straddles purchase so they use Uniswap v3 instead of GMX.

[closes issue-378](https://linear.app/dopex/issue/DOP-378/gmx-error-when-purchasing-rdpx-straddles)

## Implementation

Change path id from 5 to 6

## Screenshots

Not available

## How to Test

Open the demo link and try to purchase DPX or rDPX straddles