### PR TITLE
fix: ssov show rewards even if 0 if is collateralSymbol (DOP-379)

### DIFF
--- a/apps/dapp/src/components/ssov/WritePositions/WritePositionData.tsx
+++ b/apps/dapp/src/components/ssov/WritePositions/WritePositionData.tsx
@@ -61,7 +61,8 @@ const WritePositionTableData = (props: Props) => {
       </TableCell>
       <TableCell>
         {accruedRewards.map((rewards, index) => {
-          return rewards.gt(0) ? (
+          return rewards.gt(0) ||
+            rewardTokens[index]?.symbol === collateralSymbol ? (
             <Typography variant="h6" key={index}>
               <NumberDisplay n={rewards} decimals={18} />{' '}
               {rewardTokens[index]?.symbol}


### PR DESCRIPTION
## Scope
Rewards should be visible if symbol == collateralSymbol even if they are 0

[closes issue-379](https://linear.app/dopex/issue/DOP-379/ssov-show-rewards-if-in-collateralsymbol)

## Implementation

Trivial check (if rewardTokens[index]?.symbol === collateralSymbol)

## Screenshots

Not available

## How to Test

Open demo link and check WritePositions table of SSOV