### PR TITLE
fix: wallet dialog injected default option (DOP-380)

### DIFF
--- a/apps/dapp/src/components/common/ConnectDialog/index.tsx
+++ b/apps/dapp/src/components/common/ConnectDialog/index.tsx
@@ -26,13 +26,8 @@ export const useConnectDialog = create<ConnectDialogState>()(
 );
 
 const ConnectDialog = () => {
-  const { connect, connectors, error, isLoading, pendingConnector } =
-    useConnect();
-
   const open = useConnectDialog((state) => state.isOpen);
   const handleClose = useConnectDialog((state) => state.close);
-
-  const { connector: activeConnector } = useAccount();
 
   const WALLET_DATA: {
     [key: string]: {
@@ -62,6 +57,16 @@ const ConnectDialog = () => {
     },
   };
 
+  const { connect, connectors, error, isLoading, pendingConnector } =
+    useConnect({
+      onError(error, variables) {
+        window.open(WALLET_DATA[variables.connector.id]!.downloadLink);
+        console.log(error);
+      },
+    });
+
+  const { connector: activeConnector } = useAccount();
+
   return (
     <Dialog open={open} handleClose={handleClose} showCloseIcon>
       <div className="text-white font-bold text-lg mb-3">Connect a Wallet</div>
@@ -74,12 +79,7 @@ const ConnectDialog = () => {
               className="w-full bg-umbra text-white rounded-lg p-3 flex space-x-3 cursor-pointer"
               key={connector.id}
               onClick={() => {
-                if (!connector.ready) {
-                  connect({ connector: connectors[connectors.length - 1]! });
-                } else {
-                  connect({ connector });
-                }
-
+                connect({ connector });
                 action && action();
               }}
             >

--- a/apps/dapp/src/components/common/ConnectDialog/index.tsx
+++ b/apps/dapp/src/components/common/ConnectDialog/index.tsx
@@ -1,7 +1,7 @@
-import { useConnect, useAccount } from 'wagmi';
-import { devtools } from 'zustand/middleware';
-import { create } from 'zustand';
 import CircularProgress from '@mui/material/CircularProgress';
+import { useAccount, useConnect } from 'wagmi';
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
 
 import { Dialog } from 'components/UI';
 
@@ -68,15 +68,14 @@ const ConnectDialog = () => {
       <div className="grid gap-3">
         {connectors.map((connector) => {
           const icon = WALLET_DATA[connector.id]?.icon;
-          const downloadLink = WALLET_DATA[connector.id]?.downloadLink;
           const action = WALLET_DATA[connector.id]?.action;
           return (
             <div
               className="w-full bg-umbra text-white rounded-lg p-3 flex space-x-3 cursor-pointer"
               key={connector.id}
               onClick={() => {
-                if (!connector.ready && downloadLink) {
-                  window.open(downloadLink);
+                if (!connector.ready) {
+                  connect({ connector: connectors[connectors.length - 1]! });
                 } else {
                   connect({ connector });
                 }

--- a/apps/dapp/src/components/ssov/WritePositions/WritePositionData.tsx
+++ b/apps/dapp/src/components/ssov/WritePositions/WritePositionData.tsx
@@ -61,7 +61,8 @@ const WritePositionTableData = (props: Props) => {
       </TableCell>
       <TableCell>
         {accruedRewards.map((rewards, index) => {
-          return rewards.gt(0) ? (
+          return rewards.gt(0) ||
+            rewardTokens[index]?.symbol === collateralSymbol ? (
             <Typography variant="h6" key={index}>
               <NumberDisplay n={rewards} decimals={18} />{' '}
               {rewardTokens[index]?.symbol}

--- a/apps/dapp/src/components/ssov/WritePositions/WritePositionData.tsx
+++ b/apps/dapp/src/components/ssov/WritePositions/WritePositionData.tsx
@@ -61,8 +61,7 @@ const WritePositionTableData = (props: Props) => {
       </TableCell>
       <TableCell>
         {accruedRewards.map((rewards, index) => {
-          return rewards.gt(0) ||
-            rewardTokens[index]?.symbol === collateralSymbol ? (
+          return rewards.gt(0) ? (
             <Typography variant="h6" key={index}>
               <NumberDisplay n={rewards} decimals={18} />{' '}
               {rewardTokens[index]?.symbol}


### PR DESCRIPTION
## Scope

<!-- Brief description of WHAT you’re doing and WHY. -->

[closes issue-380](https://linear.app/dopex/issue/DOP-380/wallet-dialog-use-injected-as-default-option)

## Implementation

Try to use last connector (injected) if the user chosen one doesn't work

## Screenshots

Not available

## How to Test

Open the demo link and try to connect while metamask and rabby are installed