### PR TITLE
fix(zdte): trade panel insufficient balance bug

### DIFF
--- a/apps/dapp/src/components/zdte/Manage/TradeCard/TradeButton.tsx
+++ b/apps/dapp/src/components/zdte/Manage/TradeCard/TradeButton.tsx
@@ -1,7 +1,5 @@
 import { useMemo } from 'react';
 
-import { BigNumber } from 'ethers';
-
 import { Button } from '@dopex-io/ui';
 
 import { ISpreadPair, IZdteUserData } from 'store/Vault/zdte';
@@ -19,7 +17,8 @@ type PositionStatus =
 
 function canOpenPosition(
   amount: number,
-  quoteTokenBalance: BigNumber,
+  totalCost: number,
+  quoteTokenBalance: number,
   selectedSpreadPair: ISpreadPair | undefined,
   canOpenSpread: boolean
 ): PositionStatus {
@@ -30,7 +29,8 @@ function canOpenPosition(
   if (amount <= 0) {
     return 'Insert an Amount';
   }
-  if (amount > getUserReadableAmount(quoteTokenBalance, DECIMALS_USD)) {
+  if (totalCost > quoteTokenBalance) {
+    console.log(getUserReadableAmount(quoteTokenBalance, DECIMALS_USD));
     return 'Insufficient Balance';
   }
   // check if it's possible to open position
@@ -54,6 +54,7 @@ const TradeButton = ({
   handleApprove,
   handleOpenPosition,
   approved,
+  totalCost,
   canOpenSpread,
 }: {
   amount: string | number;
@@ -63,15 +64,17 @@ const TradeButton = ({
   handleOpenPosition: () => Promise<void>;
   approved: boolean;
   canOpenSpread: boolean;
+  totalCost: number;
 }) => {
   const positionStatus: PositionStatus = useMemo(() => {
     return canOpenPosition(
       Number(amount),
-      userZdteLpData?.userQuoteTokenBalance!,
+      totalCost,
+      getUserReadableAmount(userZdteLpData.userQuoteTokenBalance, DECIMALS_USD),
       selectedSpreadPair,
       canOpenSpread
     );
-  }, [selectedSpreadPair, amount, userZdteLpData, canOpenSpread]);
+  }, [selectedSpreadPair, totalCost, amount, userZdteLpData, canOpenSpread]);
 
   return (
     <Button

--- a/apps/dapp/src/components/zdte/Manage/TradeCard/TradeButton.tsx
+++ b/apps/dapp/src/components/zdte/Manage/TradeCard/TradeButton.tsx
@@ -30,7 +30,6 @@ function canOpenPosition(
     return 'Insert an Amount';
   }
   if (totalCost > quoteTokenBalance) {
-    console.log(getUserReadableAmount(quoteTokenBalance, DECIMALS_USD));
     return 'Insufficient Balance';
   }
   // check if it's possible to open position

--- a/apps/dapp/src/components/zdte/Manage/TradeCard/index.tsx
+++ b/apps/dapp/src/components/zdte/Manage/TradeCard/index.tsx
@@ -491,6 +491,7 @@ const TradeCard = () => {
         handleOpenPosition={handleOpenPosition}
         approved={approved}
         canOpenSpread={canOpenSpread}
+        totalCost={premium + openingFees}
       />
     </div>
   );


### PR DESCRIPTION
<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope

<!-- Brief description of WHAT you’re doing and WHY. -->

[closes issue-###](https://link-to-your-issue)

## Implementation

With @pair

<!--

Fixes 'insufficient balance' prompt that disables the purchase button in zdte page. The check made was amount against user balance, when it should be premium + opening fee against total balance.

-->

## Screenshots

|         | before | after |
| ------- | ------ | ----- |
| desktop |        |       |
| mobile  |        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes could help colleagues that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->
