### PR TITLE
fix: ssov padding (DOP-346)

### DIFF
--- a/apps/dapp/src/components/ssov/DepositPanel/index.tsx
+++ b/apps/dapp/src/components/ssov/DepositPanel/index.tsx
@@ -463,8 +463,8 @@ const DepositPanel = () => {
       </Box>
       {!isTokenSelectorOpen && (
         <Box>
-          <Box className="rounded-lg p-3 pt-2.5 pb-0 border border-neutral-800 w-full">
-            <Box className="mt-2 flex">
+          <Box className="rounded-lg p-0 mt-4 border border-neutral-800 w-full">
+            <Box className="flex">
               <Box className={'w-full'}>
                 <Select
                   className="bg-mineshaft hover:bg-mineshaft hover:opacity-80 rounded-md px-2 text-white"


### PR DESCRIPTION
## Scope

Fix ssov deposit card padding

[closes issue-346](https://linear.app/dopex/issue/DOP-346/no-padding-below-list-box)

## Implementation

Changes to tailwind classes

## Screenshots

Not available

## How to Test

Open demo link and click on a SSOV
