### PR TITLE
fix: strikes dropdown margin top (DOP-345)

### DIFF
--- a/apps/dapp/src/components/ssov/PurchaseDialog/index.tsx
+++ b/apps/dapp/src/components/ssov/PurchaseDialog/index.tsx
@@ -724,7 +724,6 @@ const PurchaseDialog = ({
                           open={Boolean(anchorEl)}
                           onClose={() => setAnchorEl(null)}
                           classes={{ paper: 'bg-umbra' }}
-                          className="mt-12"
                         >
                           {strikes.map((strike, strikeIndex) => (
                             <MenuItem


### PR DESCRIPTION
## Scope

Fix margin top of strikes dropdown

[closes issue-345](https://linear.app/dopex/issue/DOP-345/strike-prices-dropdown-is-not-properly-aligned)

## Implementation

Remove mt-12

## Screenshots

Not available

## How to Test

Open a SSOV from the demo link and try to purchase an option
