### PR TITLE
fix: getUserReadableAmount parsing (DOP-406)

### DIFF
--- a/apps/dapp/src/utils/contracts/getUserReadableAmount.ts
+++ b/apps/dapp/src/utils/contracts/getUserReadableAmount.ts
@@ -5,5 +5,6 @@ export default function getUserReadableAmount(
   decimals: string | number = 18
 ): number {
   if (amount === undefined || amount === null) return 0;
+  if (typeof amount !== 'string') amount = String(amount);
   return Number(ethersUtils.formatUnits(amount, Number(decimals)));
 }


### PR DESCRIPTION
## Scope

SSOVs don't load because of getUserReadableAmount.
This PR fixes it passing the amount as a string to formatUnits.

[closes issue-406](https://linear.app/dopex/issue/DOP-406/ssovs-dont-load)

## Implementation

String() around amount

## Screenshots

Not available

## How to Test

Open SSOVs pages