### PR TITLE
fix: breakeven for zdte positions (DOP-416)

### DIFF
--- a/apps/dapp/src/store/Vault/zdte/index.ts
+++ b/apps/dapp/src/store/Vault/zdte/index.ts
@@ -333,10 +333,21 @@ export const createZdteSlice: StateCreator<
             .mul(oneEBigNumber(DECIMALS_TOKEN))
             .div(pos.positions || BigNumber.from(1))
             .mul(100);
-          const breakeven =
-            pos.longStrike > pos.shortStrike
-              ? pos.longStrike.sub(finalCost)
-              : pos.longStrike.add(finalCost);
+
+          let breakeven;
+
+          if (pos.isPut) {
+            breakeven =
+              pos.longStrike > pos.shortStrike
+                ? pos.longStrike.add(finalCost)
+                : pos.longStrike.sub(finalCost);
+          } else {
+            breakeven =
+              pos.longStrike > pos.shortStrike
+                ? pos.longStrike.sub(finalCost)
+                : pos.longStrike.add(finalCost);
+          }
+
           return {
             ...pos,
             livePnl: livePnl,


### PR DESCRIPTION
## Scope

A user reported breakeven price is not correct
This PR aims to fix it.

[closes issue-416](https://linear.app/dopex/issue/DOP-416/fix-breakeven-for-zdte-positions)

## Implementation

We invert the standard logic if isPut is true

## Screenshots

Not available

## How to Test

Open ZDTE page and check your positions