### PR TITLE
feat: show target price in scalp orders table

### DIFF
--- a/apps/dapp/src/components/scalps/Orders/OrdersTable.tsx
+++ b/apps/dapp/src/components/scalps/Orders/OrdersTable.tsx
@@ -28,7 +28,8 @@ const OrdersTable = () => {
   const tableHeadings = [
     'Positions',
     'Type',
-    'Price',
+    'Target price',
+    'Estimated Entry',
     'Collateral',
     'Expiry',
     'View on Etherscan',
@@ -37,6 +38,7 @@ const OrdersTable = () => {
   const ordersKeys = [
     'positions',
     'isOpen',
+    'target',
     'price',
     'collateral',
     'expiry',

--- a/apps/dapp/src/components/scalps/Orders/OrdersTable.tsx
+++ b/apps/dapp/src/components/scalps/Orders/OrdersTable.tsx
@@ -108,8 +108,11 @@ const OrdersTable = () => {
               ),
               4
             ) +
-            ' ' +
-            optionScalpData.quoteSymbol
+              ' ' +
+              optionScalpData.quoteSymbol ===
+            'USDC'
+            ? 'USDC.e'
+            : 'USDC'
           : '-';
       }
 

--- a/apps/dapp/src/components/scalps/Orders/OrdersTable.tsx
+++ b/apps/dapp/src/components/scalps/Orders/OrdersTable.tsx
@@ -83,7 +83,7 @@ const OrdersTable = () => {
           : null;
       }
 
-      if (key === 'size' || key === 'price') {
+      if (key === 'size' || key === 'price' || key === 'target') {
         data = order[key]
           ? formatAmount(
               Number(

--- a/apps/dapp/src/components/scalps/Positions/PositionsTable.tsx
+++ b/apps/dapp/src/components/scalps/Positions/PositionsTable.tsx
@@ -84,7 +84,9 @@ const PositionsTable = ({ tab }: { tab: string }) => {
             {' | '}
             <span>{formatAmount(leverage, 1)}x</span>
             {' | '}
-            <span>{`${baseSymbol}${quoteSymbol}`}</span>
+            <span>{`${baseSymbol}${
+              quoteSymbol === 'USDC' ? 'USDC.e' : quoteSymbol
+            }`}</span>
           </h5>
         ),
         percentage:
@@ -323,7 +325,8 @@ const PositionsTable = ({ tab }: { tab: string }) => {
           ),
           4
         );
-        rightContent = optionScalpData.quoteSymbol;
+        rightContent =
+          optionScalpData.quoteSymbol === 'USDC' ? 'USDC.e' : 'USDC';
         rightContentStyle += ' text-xs hidden md:inline-block';
       }
 
@@ -332,10 +335,10 @@ const PositionsTable = ({ tab }: { tab: string }) => {
         data = (
           <Countdown
             date={new Date((position.openedAt + position.timeframe) * 1000)}
-            renderer={({ minutes, seconds }) => {
+            renderer={({ hours, minutes, seconds }) => {
               return (
                 <span className="text-xs md:text-sm text-white pt-1">
-                  {minutes}m {seconds}s
+                  {hours}h {minutes}m {seconds}s
                 </span>
               );
             }}

--- a/apps/dapp/src/store/Vault/scalps/index.ts
+++ b/apps/dapp/src/store/Vault/scalps/index.ts
@@ -68,6 +68,7 @@ export interface ScalpOrder {
   timeframe: BigNumber;
   collateral: BigNumber;
   price: BigNumber;
+  target: BigNumber;
   expiry: BigNumber | null;
   filled: boolean;
   type: string;
@@ -299,6 +300,14 @@ export const createOptionScalpSlice: StateCreator<
 
       const price = BigNumber.from(Math.round(1.0001 ** tick * 10 ** 18));
 
+      let target;
+
+      if (openOrder['isShort']) {
+        target = BigNumber.from(Math.round(1.0001 ** ticks[1] * 10 ** 18));
+      } else {
+        target = BigNumber.from(Math.round(1.0001 ** ticks[0] * 10 ** 18));
+      }
+
       const maxFundingTime = await limitOrdersContract.maxFundingTime();
 
       const expiry = openOrder['timestamp'].add(maxFundingTime);
@@ -320,6 +329,7 @@ export const createOptionScalpSlice: StateCreator<
           timeframe: timeframe,
           collateral: openOrder['collateral'],
           price: price,
+          target: target,
           expiry: expiry,
           filled: openOrder['filled'],
           positions: positions,
@@ -354,6 +364,14 @@ export const createOptionScalpSlice: StateCreator<
 
       const price = BigNumber.from(Math.round(1.0001 ** tick * 10 ** 18));
 
+      let target;
+
+      if (scalpPosition['isShort']) {
+        target = BigNumber.from(Math.round(1.0001 ** ticks[0] * 10 ** 18));
+      } else {
+        target = BigNumber.from(Math.round(1.0001 ** ticks[1] * 10 ** 18));
+      }
+
       const positions = scalpPosition['size']
         .mul(BigNumber.from(10 ** optionScalpData.quoteDecimals.toNumber()))
         .div(price);
@@ -368,6 +386,7 @@ export const createOptionScalpSlice: StateCreator<
           timeframe: scalpPosition['timeframe'],
           collateral: scalpPosition['collateral'],
           price: price,
+          target: target,
           expiry: null,
           positions: positions,
           type: 'close',


### PR DESCRIPTION
## Scope

This PR adds a column to the scalp orders table 'Target price', or the price that must be reach for your order to be filled.
The 'Estimated entry' will instead tells user what will be his entry after the order has been filled.

## Implementation

Use further range tick to compute the corresponding price.

## Screenshots

Not available

## How to Test

Open demo link