### PR TITLE
fix: scalp positions table limit close button text

### DIFF
--- a/apps/dapp/src/components/scalps/LimitOrderPopover/index.tsx
+++ b/apps/dapp/src/components/scalps/LimitOrderPopover/index.tsx
@@ -88,12 +88,12 @@ const LimitOrderPopover = (props: LimitOrderPopoverProps) => {
         placement="top"
       >
         <Button
-          className="cursor-pointer text-white w-[5.7rem]"
+          className="cursor-pointer text-white w-[2.7rem]"
           color={'primary'}
           variant={'contained'}
           onClick={handleOpenLimitOrderPopover}
         >
-          <span className="text-xs md:sm">Limit Close</span>
+          <span className="text-xs md:sm">Limit</span>
         </Button>
       </Tooltip>
       <Popover


### PR DESCRIPTION
## Scope

To save space we change the text of the button to "Limit"

## Implementation

Simple text replace and width adjustment

## Screenshots

Not available

## How to Test

Open demo link