### PR TITLE
fix: scalps trade card

### DIFF
--- a/apps/dapp/src/components/scalps/TradeCard/index.tsx
+++ b/apps/dapp/src/components/scalps/TradeCard/index.tsx
@@ -719,7 +719,30 @@ const TradeCard = () => {
                 )}{' '}
                 {isShort
                   ? optionScalpData?.baseSymbol!
+                  : optionScalpData?.quoteSymbol === 'USDC'
+                  ? 'USDC.e'
                   : optionScalpData?.quoteSymbol!}
+              </h6>
+            </div>
+          </div>
+          <div className={'flex mb-2'}>
+            <h6 className="text-stieglitz ml-0 mr-auto text-[0.8rem]">
+              Wallet Balance
+            </h6>
+            <div className={'text-right'}>
+              <h6 className="text-white mr-auto ml-0 text-[0.8rem]">
+                {formatAmount(
+                  Number(
+                    utils.formatUnits(
+                      userTokenBalance,
+                      optionScalpData?.quoteDecimals!.toNumber()!
+                    )
+                  ),
+                  3
+                )}{' '}
+                {optionScalpData?.quoteSymbol === 'USDC'
+                  ? 'USDC.e'
+                  : optionScalpData?.quoteSymbol}
               </h6>
             </div>
           </div>
@@ -730,7 +753,9 @@ const TradeCard = () => {
             <div className={'text-right'}>
               <h6 className="text-white mr-auto ml-0 text-[0.8rem]">
                 {formatAmount(positionDetails.marginInQuote, 3)}{' '}
-                {optionScalpData?.quoteSymbol}
+                {optionScalpData?.quoteSymbol === 'USDC'
+                  ? 'USDC.e'
+                  : optionScalpData?.quoteSymbol}
               </h6>
             </div>
           </div>
@@ -749,7 +774,9 @@ const TradeCard = () => {
                   ),
                   2
                 )}{' '}
-                {optionScalpData?.quoteSymbol}
+                {optionScalpData?.quoteSymbol === 'USDC'
+                  ? 'USDC.e'
+                  : optionScalpData?.quoteSymbol}
               </h6>
             </div>
           </div>
@@ -757,24 +784,30 @@ const TradeCard = () => {
             <h6 className="text-stieglitz ml-0 mr-auto text-[0.8rem]">Fees</h6>
             <div className={'text-right'}>
               <h6 className="text-white mr-auto ml-0 text-[0.8rem]">
-                {optionScalpData?.feeOpenPosition
-                  ? formatAmount(
-                      Number(
-                        utils.formatUnits(
-                          posSize,
-                          optionScalpData?.quoteDecimals!.toNumber()!
-                        )
-                      ) *
+                <span className={orderType === 'Limit' ? 'text-green-500' : ''}>
+                  {orderType === 'Limit'
+                    ? 0
+                    : optionScalpData?.feeOpenPosition
+                    ? formatAmount(
                         Number(
                           utils.formatUnits(
-                            optionScalpData?.feeOpenPosition!,
-                            10
+                            posSize,
+                            optionScalpData?.quoteDecimals!.toNumber()!
                           )
-                        ),
-                      2
-                    )
-                  : 0}{' '}
-                {optionScalpData?.quoteSymbol}
+                        ) *
+                          Number(
+                            utils.formatUnits(
+                              optionScalpData?.feeOpenPosition!,
+                              10
+                            )
+                          ),
+                        2
+                      )
+                    : 0}{' '}
+                  {optionScalpData?.quoteSymbol === 'USDC'
+                    ? 'USDC.e'
+                    : optionScalpData?.quoteSymbol}
+                </span>
               </h6>
             </div>
           </div>


### PR DESCRIPTION
## Scope

Show USDC.e instead of USDC
Show available balance
Show fees in green if it's a limit order

## Implementation

Nothing to report

## Screenshots

Not available

## How to Test

See the demo