### PR TITLE
fix: Add percentage symbols

### DIFF
--- a/apps/dapp/src/components/ssov/Description/index.tsx
+++ b/apps/dapp/src/components/ssov/Description/index.tsx
@@ -4,10 +4,10 @@ import { BigNumber, ethers } from 'ethers';
 import cx from 'classnames';
 import format from 'date-fns/format';
 import noop from 'lodash/noop';
-import { useBoundStore } from 'store';
 import Action from 'svgs/icons/Action';
 import Coin from 'svgs/icons/Coin';
 
+import { useBoundStore } from 'store';
 import { Reward, SsovV3Data, SsovV3EpochData } from 'store/Vault/ssov';
 
 import SignerButton from 'components/common/SignerButton';
@@ -77,7 +77,7 @@ const Description = ({
     if (typeof APY !== 'string') {
       return `upto ${Math.max(
         ...(APY as string[]).map((apy: string) => Number(apy))
-      )}`;
+      )}%`;
     }
 
     return Number(APY) > 0 && APY !== 'Infinity'

--- a/apps/dapp/src/components/ssov/SsovCard/index.tsx
+++ b/apps/dapp/src/components/ssov/SsovCard/index.tsx
@@ -62,7 +62,7 @@ function SsovCard(props: any) {
         : '...';
 
     if (typeof apy !== 'string') {
-      _apy = `upto ${Math.max(...apy.map((apy: string) => Number(apy)))}`;
+      _apy = `upto ${Math.max(...apy.map((apy: string) => Number(apy)))}%`;
     }
 
     return [

--- a/apps/dapp/src/pages/scalps/leaderboard/index.tsx
+++ b/apps/dapp/src/pages/scalps/leaderboard/index.tsx
@@ -176,7 +176,7 @@ const LeaderBoard = () => {
                             sort === SORT_OPTIONS[0]
                               ? position.totalPnL
                               : position.totalVolume,
-                            sort === SORT_OPTIONS[0] ? 6 : 18
+                            6
                           ),
                           2
                         )}

--- a/apps/dapp/src/pages/scalps/leaderboard/index.tsx
+++ b/apps/dapp/src/pages/scalps/leaderboard/index.tsx
@@ -1,17 +1,18 @@
-import Head from 'next/head';
-
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import Head from 'next/head';
+import { ethers } from 'ethers';
 
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
 import EqualizerIcon from '@mui/icons-material/Equalizer';
 import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUp from '@mui/icons-material/KeyboardArrowUp';
+
 import cx from 'classnames';
+
 import { useBoundStore } from 'store';
 
 import AppBar from 'components/common/AppBar';
 
-import { getUserReadableAmount } from 'utils/contracts';
 import { formatAmount, smartTrim } from 'utils/general';
 
 const TOKENS = ['ARB', 'ETH'];
@@ -171,11 +172,11 @@ const LeaderBoard = () => {
                       >
                         $
                         {formatAmount(
-                          getUserReadableAmount(
+                          ethers.utils.formatUnits(
                             sort === SORT_OPTIONS[0]
                               ? position.totalPnL
                               : position.totalVolume,
-                            6
+                            sort === SORT_OPTIONS[0] ? 6 : 18
                           ),
                           2
                         )}


### PR DESCRIPTION
% symbols were not added to ssov APYs

Before:
![Screenshot 2023-06-22 at 4 10 10 PM](https://github.com/dopex-io/elvarg/assets/90272722/a7498451-0df7-45a5-9d9d-9bd73efe0652)

After:
![Screenshot 2023-06-22 at 4 09 59 PM](https://github.com/dopex-io/elvarg/assets/90272722/4616ec65-9bfa-4dd5-a5ea-df6ddc0e0bfb)
