### PR TITLE
fix: hitting back on a ssov page breaks dapp (DOP-428)

### DIFF
--- a/apps/dapp/src/components/ssov/SsovCard/index.tsx
+++ b/apps/dapp/src/components/ssov/SsovCard/index.tsx
@@ -130,7 +130,7 @@ function SsovCard(props: any) {
               return <InfoBox key={item.heading} {...item} />;
             })}
           </Box>
-          <Link href={`/ssov/${symbol}`}>
+          <Link href={`/ssov/${symbol}`} passHref>
             <CustomButton size="medium" className="my-4" fullWidth>
               Manage
             </CustomButton>


### PR DESCRIPTION
## Scope

fix hitting back on a ssov page breaking dapp

## Implementation

pass href to the manage button


## Screenshots

N/A

## How to Test

Go to ssov page on the preview link, click on a ssov and hit back, it should load back the ssov home page normally
