### PR TITLE
fix: update ssov signer if ssov data has loaded (DOP-433)

### DIFF
--- a/apps/dapp/src/components/ssov/Manage/index.tsx
+++ b/apps/dapp/src/components/ssov/Manage/index.tsx
@@ -1,15 +1,16 @@
 import { useEffect } from 'react';
 
 import Box from '@mui/material/Box';
+
 import { useBoundStore } from 'store';
 
-import Typography from 'components/UI/Typography';
 import PageLoader from 'components/common/PageLoader';
 import DepositPanel from 'components/ssov/DepositPanel';
 import Description from 'components/ssov/Description';
 import ExerciseList from 'components/ssov/ExerciseList';
 import Stats from 'components/ssov/Stats';
 import WritePositions from 'components/ssov/WritePositions';
+import Typography from 'components/UI/Typography';
 
 import { CHAINS } from 'constants/chains';
 
@@ -30,8 +31,9 @@ const Manage = (props: { ssov: string }) => {
   } = useBoundStore();
 
   useEffect(() => {
+    if (!ssovEpochData) return;
     updateSsovV3Signer();
-  }, [signer, updateSsovV3Signer, selectedPoolName, chainId]);
+  }, [signer, updateSsovV3Signer, selectedPoolName, chainId, ssovEpochData]);
 
   useEffect(() => {
     updateSsovV3();
@@ -40,10 +42,9 @@ const Manage = (props: { ssov: string }) => {
   useEffect(() => {
     if (!ssovData) return;
     updateSsovV3EpochData();
-  }, [ssovData, updateSsovV3EpochData, chainId]);
+  }, [ssovData, updateSsovV3EpochData, chainId, updateSsovV3Signer]);
 
   useEffect(() => {
-    if (!ssovEpochData) return;
     updateSsovV3UserData();
   }, [ssovEpochData, updateSsovV3UserData, chainId]);
 

--- a/apps/dapp/src/components/ssov/Manage/index.tsx
+++ b/apps/dapp/src/components/ssov/Manage/index.tsx
@@ -42,7 +42,7 @@ const Manage = (props: { ssov: string }) => {
   useEffect(() => {
     if (!ssovData) return;
     updateSsovV3EpochData();
-  }, [ssovData, updateSsovV3EpochData, chainId, updateSsovV3Signer]);
+  }, [ssovData, updateSsovV3EpochData, chainId]);
 
   useEffect(() => {
     updateSsovV3UserData();

--- a/apps/dapp/src/store/Vault/ssov/index.ts
+++ b/apps/dapp/src/store/Vault/ssov/index.ts
@@ -201,7 +201,6 @@ export const createSsovV3Slice: StateCreator<
     );
 
     let ssovStakingRewardsWithSigner = getStakingRewardsContract();
-    console.log(ssovStakingRewardsWithSigner?.address);
 
     _ssovSigner = {
       ssovContractWithSigner: _ssovContractWithSigner,


### PR DESCRIPTION
ssovSigner slice which holds instances of contracts with signer depends on the epoch of the SSOV. specifically the staking contract which has to return the legacy staking contract depending on the SSOV and epoch. Hence, I added a check to see if ssovData is available then update/load ssovSigner.