### PR TITLE
feat: calc premiums

### DIFF
--- a/apps/dapp/src/store/Vault/ssov/index.ts
+++ b/apps/dapp/src/store/Vault/ssov/index.ts
@@ -445,22 +445,30 @@ export const createSsovV3Slice: StateCreator<
       ssovAddress
     );
 
-    const data = await Promise.all(
+    const writePositionsData = await Promise.all(
       writePositions.map((i) => {
         return ssov.writePosition(i);
       })
     );
 
     const checkpointData = await Promise.all(
-      data.map((pos) => {
+      writePositionsData.map((pos) => {
         return ssov.checkpoints(pos.epoch, pos.strike, pos.checkpointIndex);
       })
     );
 
-    const moreData = await Promise.all(
-      writePositions.map((i) => {
-        return ssovViewerContract.getWritePositionValue(i, ssovAddress);
-      })
+    const accruedPremiumsPerPosition = writePositionsData.map(
+      ({ collateralAmount }, index) => {
+        const { activeCollateral, totalCollateral, accruedPremium } =
+          checkpointData[index];
+        const activeCollateralShare = collateralAmount
+          .mul(activeCollateral)
+          .div(totalCollateral);
+        const accruedPremiumForCurrentPosition = activeCollateral.eq(0)
+          ? BigNumber.from(0)
+          : activeCollateralShare.mul(accruedPremium).div(activeCollateral);
+        return accruedPremiumForCurrentPosition;
+      }
     );
 
     let _rewardTokens: TokenData[][] = [];
@@ -521,7 +529,7 @@ export const createSsovV3Slice: StateCreator<
       }
     }
 
-    const _writePositions = data.map((o, i) => {
+    const _writePositions = writePositionsData.map((o, i) => {
       const utilization = checkpointData[i]?.activeCollateral.isZero()
         ? BigNumber.from(0)
         : checkpointData[i]?.activeCollateral
@@ -533,8 +541,8 @@ export const createSsovV3Slice: StateCreator<
         collateralAmount: o.collateralAmount,
         epoch: o.epoch.toNumber(),
         strike: o.strike,
-        accruedRewards: moreData[i]?.rewardTokenWithdrawAmounts || [],
-        accruedPremiums: moreData[i]?.accruedPremium || BigNumber.from(0),
+        accruedRewards: [],
+        accruedPremiums: accruedPremiumsPerPosition[i],
         utilization: utilization!,
         stakeRewardAmounts: _rewardAmounts[i],
         stakeRewardTokens: _rewardTokens[i],


### PR DESCRIPTION
Problem: 
SsovViewer reverts when writePositionValue is called.

![image](https://github.com/dopex-io/elvarg/assets/90272722/a45e1547-df81-464a-9afa-492b3e19beb2)

Solution:
Since writePositionValue() usage has been deprecated, and the only values from that we use are rewards and accruedPremiums for a writePosition, I've written code to calculate accrued premiums and disregarded rewards as we are now using staking rewards.
