### PR TITLE
fix: extra percentage symbol

### DIFF
--- a/apps/dapp/src/components/ssov/Description/index.tsx
+++ b/apps/dapp/src/components/ssov/Description/index.tsx
@@ -77,11 +77,11 @@ const Description = ({
     if (typeof APY !== 'string') {
       return `upto ${Math.max(
         ...(APY as string[]).map((apy: string) => Number(apy))
-      )}%`;
+      )}`;
     }
 
     return Number(APY) > 0 && APY !== 'Infinity'
-      ? formatAmount(APY, 0, true).toString() + '%'
+      ? formatAmount(APY, 0, true).toString()
       : '...';
   }, [APY]);
 


### PR DESCRIPTION
Before:
![image](https://github.com/dopex-io/elvarg/assets/90272722/4f91445a-7301-4785-8259-9f326f3c1b3c)
After:
![image](https://github.com/dopex-io/elvarg/assets/90272722/09452842-9891-4f4d-9586-31517e80a16f)

