### PR TITLE
fix: consider collateral exchange rate for purchase (DOP-439)

### DIFF
--- a/apps/dapp/src/components/ssov/PurchaseDialog/index.tsx
+++ b/apps/dapp/src/components/ssov/PurchaseDialog/index.tsx
@@ -11,14 +11,15 @@ import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 
 import { ERC20__factory } from '@dopex-io/sdk';
 import format from 'date-fns/format';
-import useSendTx from 'hooks/useSendTx';
-import { useBoundStore } from 'store';
 import AlarmIcon from 'svgs/icons/AlarmIcon';
 import BigCrossIcon from 'svgs/icons/BigCrossIcon';
 import CircleIcon from 'svgs/icons/CircleIcon';
 import { useDebounce } from 'use-debounce';
 
+import { useBoundStore } from 'store';
 import { SsovV3Data, SsovV3EpochData } from 'store/Vault/ssov';
+
+import useSendTx from 'hooks/useSendTx';
 
 import InputWithTokenSelector from 'components/common/InputWithTokenSelector';
 import PnlChart from 'components/common/PnlChart';
@@ -544,14 +545,19 @@ const PurchaseDialog = ({
   const purchaseButtonProps = useMemo(() => {
     const totalCost = routerMode ? quote.amountOut : state.totalCost;
 
+    const availableCollateralForStrike = (
+      availableCollateralForStrikes[strikeIndex] ?? BigNumber.from(0)
+    ).div(ssovEpochData.collateralExchangeRate);
+
     const disabled = Boolean(
       optionsAmount <= 0 ||
         isPurchaseStatsLoading ||
         (isPut
-          ? availableCollateralForStrikes[strikeIndex]!.mul(oneEBigNumber(8))
+          ? availableCollateralForStrike
+              .mul(oneEBigNumber(8))
               .div(getContractReadableAmount(strikes[strikeIndex]!, 8))
               .lt(getContractReadableAmount(optionsAmount, 18))
-          : availableCollateralForStrikes[strikeIndex]!.lt(
+          : availableCollateralForStrike.lt(
               getContractReadableAmount(optionsAmount, 18)
             )) ||
         (isPut
@@ -613,6 +619,7 @@ const PurchaseDialog = ({
       onClick,
     };
   }, [
+    ssovEpochData.collateralExchangeRate,
     quoteDataLoading,
     quote,
     routerMode,
@@ -785,12 +792,16 @@ const PurchaseDialog = ({
                         {formatAmount(
                           isPut
                             ? getUserReadableAmount(
-                                availableCollateralForStrikes[strikeIndex]!,
-                                18
+                                availableCollateralForStrikes[strikeIndex]!.div(
+                                  ssovEpochData.collateralExchangeRate
+                                ),
+                                10
                               ) / Number(strikes[strikeIndex])
                             : getUserReadableAmount(
-                                availableCollateralForStrikes[strikeIndex]!,
-                                18
+                                availableCollateralForStrikes[strikeIndex]!.div(
+                                  ssovEpochData.collateralExchangeRate
+                                ),
+                                10
                               ),
                           5
                         )}

--- a/apps/dapp/src/components/ssov/Stats/index.tsx
+++ b/apps/dapp/src/components/ssov/Stats/index.tsx
@@ -90,7 +90,6 @@ const StatsTableData = (props: StatsTableDataProps & { price: number }) => {
           {formatAmount(isPut ? totalPremiums : totalPremiums * price, 2)}
         </Box>
       </TableCell>
-      {/* @TODO Remove when all ssovs support staking rewards */}
       {stakingRewards && (
         <TableCell align="left" className="border-0 py-1">
           {stakingRewards.length > 0 ? (


### PR DESCRIPTION
Issue:
When available collateral is calculated on the purchase dialog of an ssov, the collateral exchange rate is not considered.

Solution:
Consider collateral exchange rate when calculating available collateral

Before: (Note that purchase dialog is not considering collateral exchange rate so the available collateral shows lesser)

Purchase dialog:

![Screenshot 2023-07-08 at 7 41 01 PM](https://github.com/dopex-io/elvarg/assets/90272722/bb5c9de1-94e8-45cb-9429-3afed87b0675)

Stats table:
![Screenshot 2023-07-08 at 7 42 01 PM](https://github.com/dopex-io/elvarg/assets/90272722/3c999fb0-f20e-464c-98a0-7d87bf5dc64d)


After: 
![Screenshot 2023-07-08 at 7 42 35 PM](https://github.com/dopex-io/elvarg/assets/90272722/aa1478ec-176f-497d-b7fd-c99441d9cd5c)
