### PR TITLE
fix: usdc logo error

### DIFF
--- a/apps/dapp/src/components/atlantics/Manage/ManageCard/index.tsx
+++ b/apps/dapp/src/components/atlantics/Manage/ManageCard/index.tsx
@@ -1,13 +1,18 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { BigNumber } from 'ethers';
-import { ERC20__factory } from '@dopex-io/sdk';
-import { Switch } from '@dopex-io/ui';
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+
 import Box from '@mui/material/Box';
 import Tooltip from '@mui/material/Tooltip';
-import useSendTx from 'hooks/useSendTx';
-import { useBoundStore } from 'store';
+
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+
+import { ERC20__factory } from '@dopex-io/sdk';
+import { Switch } from '@dopex-io/ui';
 import LockerIcon from 'svgs/icons/LockerIcon';
+
+import { useBoundStore } from 'store';
+
+import useSendTx from 'hooks/useSendTx';
 
 import MaxStrikeInput from 'components/atlantics/Manage/ManageCard/MaxStrikeInput';
 import PoolStats from 'components/atlantics/Manage/ManageCard/PoolStats';
@@ -248,8 +253,8 @@ const ManageCard = (props: ManageCardProps) => {
                 role="button"
               >
                 <img
-                  src={`/images/tokens/${depositToken?.toLowerCase()}.svg`}
-                  alt={(depositToken || underlying).toLowerCase()}
+                  src={`/images/tokens/usdc.svg`}
+                  alt="usdc"
                   className="w-[2.2rem]"
                 />
                 <Typography variant="h5" className="my-auto">


### PR DESCRIPTION
<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope
Fix USDC logo to show up when wallet is disconnected

<!-- Brief description of WHAT you’re doing and WHY. -->

https://linear.app/dopex/issue/DOP-443

## Screenshots

|         | before | after |
| ------- | ------ | ----- |
| desktop |   
![image](https://github.com/dopex-io/elvarg/assets/109383132/1ec83a9b-1db2-4d0f-be15-19b4243f421a)
     |     
<img width="361" alt="image" src="https://github.com/dopex-io/elvarg/assets/109383132/263c564c-cd82-4b46-8a28-9727329014a2">
  |
| mobile  |        |       |

## How to Test
go to /atlantics/manage/WETH-PUTS-WEEKLY and disconnect wallet to see the USDC logo