### PR TITLE
fix: show connect button when wallet isnt connected

### DIFF
--- a/apps/dapp/src/components/common/ConnectButton/index.tsx
+++ b/apps/dapp/src/components/common/ConnectButton/index.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
 
 import { Button } from '@dopex-io/ui';
-import { useEthersProvider } from 'hooks/useEthersProvider';
-import { useEthersSigner } from 'hooks/useEthersSigners';
+import cx from 'classnames';
 import { useAccount, useEnsAvatar, useEnsName, useNetwork } from 'wagmi';
 
 import { useBoundStore } from 'store';
+
+import { useEthersProvider } from 'hooks/useEthersProvider';
+import { useEthersSigner } from 'hooks/useEthersSigners';
 
 import { smartTrim } from 'utils/general';
 
@@ -14,7 +16,7 @@ import { DEFAULT_CHAIN_ID } from 'constants/env';
 import { useConnectDialog } from '../ConnectDialog';
 import WalletDialog from '../WalletDialog';
 
-export function ConnectButton() {
+export function ConnectButton({ className }: { className?: string }) {
   const [walletDialog, setWalletDialog] = useState(false);
 
   const { updateState, userAssetBalances } = useBoundStore();
@@ -54,7 +56,10 @@ export function ConnectButton() {
       />
       {address ? (
         <Button
-          className="text-white border-cod-gray flex items-center"
+          className={cx(
+            'text-white border-cod-gray flex items-center',
+            className
+          )}
           color="carbon"
           onClick={handleClick}
         >
@@ -67,6 +72,7 @@ export function ConnectButton() {
           onClick={() => {
             open();
           }}
+          className={className}
         >
           Connect Wallet
         </Button>

--- a/apps/dapp/src/components/scalps/DepositCard/index.tsx
+++ b/apps/dapp/src/components/scalps/DepositCard/index.tsx
@@ -11,6 +11,7 @@ import { useBoundStore } from 'store';
 
 import useSendTx from 'hooks/useSendTx';
 
+import ConnectButton from 'components/common/ConnectButton';
 import EstimatedGasCostButton from 'components/common/EstimatedGasCostButton';
 import Wrapper from 'components/ssov/Wrapper';
 
@@ -394,25 +395,29 @@ const DepositCard = () => {
           <div className="rounded-md flex flex-col mb-2.5 p-4 pt-2 pb-2.5 border border-neutral-800 w-full bg-neutral-800">
             <EstimatedGasCostButton gas={500000} chainId={chainId} />
           </div>
-          <Button
-            size="small"
-            className="w-full"
-            color={
-              !approved || (amount > 0 && amount <= readableUserTokenBalance)
-                ? 'primary'
-                : 'mineshaft'
-            }
-            disabled={amount <= 0}
-            onClick={approved ? handleDeposit : handleApprove}
-          >
-            <p className="text-[0.8rem]">
-              {loading ? (
-                <CircularProgress className="text-white" size="1rem" />
-              ) : (
-                depositButtonMessage
-              )}
-            </p>
-          </Button>
+          {accountAddress === undefined ? (
+            <ConnectButton className="w-full" />
+          ) : (
+            <Button
+              size="small"
+              className="w-full"
+              color={
+                !approved || (amount > 0 && amount <= readableUserTokenBalance)
+                  ? 'primary'
+                  : 'mineshaft'
+              }
+              disabled={amount <= 0}
+              onClick={approved ? handleDeposit : handleApprove}
+            >
+              <p className="text-[0.8rem]">
+                {loading ? (
+                  <CircularProgress className="text-white" size="1rem" />
+                ) : (
+                  depositButtonMessage
+                )}
+              </p>
+            </Button>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope
Show connect button if wallet isn't connected

<!-- Brief description of WHAT you’re doing and WHY. -->

[closes issue-###](https://linear.app/dopex/issue/DOP-442/scalps-the-approve-button-is-clickable-and-goes-to-loading-state-even)

## Implementation

With @pair

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

|         | before | after |
| ------- | ------ | ----- |
| desktop |   
![image](https://github.com/dopex-io/elvarg/assets/109383132/f41c6afd-1bf6-4ed9-bb84-e617fa286e29)
     |   
![image](https://github.com/dopex-io/elvarg/assets/109383132/fef5cf50-542d-42ce-a4f4-b393e9806c08)
    |
| mobile  |        |       |

## How to Test
Disconnect wallet and go to scalps page.