### PR TITLE
fix: show straddle asset

### DIFF
--- a/apps/dapp/src/components/portfolio/Deposits/index.tsx
+++ b/apps/dapp/src/components/portfolio/Deposits/index.tsx
@@ -1,19 +1,21 @@
+import { useMemo, useState } from 'react';
 import Link from 'next/link';
 
-import { useMemo, useState } from 'react';
-
-import SearchIcon from '@mui/icons-material/Search';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Input from '@mui/material/Input';
+
+import SearchIcon from '@mui/icons-material/Search';
+
 import cx from 'classnames';
+
 import { useBoundStore } from 'store';
 
-import CustomButton from 'components/UI/Button';
-import Typography from 'components/UI/Typography';
 import Filter from 'components/common/Filter';
 import SignerButton from 'components/common/SignerButton';
+import CustomButton from 'components/UI/Button';
+import Typography from 'components/UI/Typography';
 
 import getUserReadableAmount from 'utils/contracts/getUserReadableAmount';
 import formatAmount from 'utils/general/formatAmount';
@@ -328,7 +330,9 @@ export default function Deposits() {
 
                   <Box className="col-span-2 text-left flex">
                     <Typography variant="h5" className="mt-1">
-                      <span className="text-white">Straddle</span>
+                      <span className="text-white">{`${
+                        deposit.vaultName.split('-')[0]
+                      } Straddle`}</span>
                     </Typography>
                   </Box>
 


### PR DESCRIPTION
<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope
Show asset for straddle.

<!-- Brief description of WHAT you’re doing and WHY. -->

closes https://linear.app/dopex/issue/DOP-455/portfolio-in-deposit-straddle-section-there-is-no-way-to-tell-which

## Implementation

With @pair

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

|         | before | after |
| ------- | ------ | ----- |
| desktop |        |  
<img width="742" alt="image" src="https://github.com/dopex-io/elvarg/assets/109383132/a5e83c8b-9872-41e8-b119-9a78857e64d1">
     |
| mobile  |        |       |

## How to Test
Navigate to /portfolio and see straddle has asset name.

<!--

A straightforward scenario of how to test your changes could help colleagues that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->
