### PR TITLE
fix: 1inch api calls

### DIFF
--- a/apps/dapp/src/components/UI/Input/index.tsx
+++ b/apps/dapp/src/components/UI/Input/index.tsx
@@ -31,6 +31,12 @@ const variants: Record<string, Record<string, string>> = {
     textPosition: 'text-right',
     alignment: 'flex justify-between items-center',
   },
+  straddles: {
+    box: 'bg-umbra pr-4 rounded-xl',
+    font: 'text-2xl text-white ml-2 font-mono',
+    textPosition: 'text-right',
+    alignment: 'flex justify-between items-center',
+  },
 };
 
 /**
@@ -80,7 +86,7 @@ const Input = (props: InputProps) => {
             input:
               variants[variant]?.['textPosition']?.concat(
                 ' ',
-                variants[variant]?.['font'] ?? ''
+                variants[variant]?.['font'] ?? '',
               ) ?? '',
           }}
           {...rest}

--- a/apps/dapp/src/components/ssov/DepositPanel/index.tsx
+++ b/apps/dapp/src/components/ssov/DepositPanel/index.tsx
@@ -9,12 +9,13 @@ import Select, { SelectChangeEvent } from '@mui/material/Select';
 
 import { ERC20__factory, SsovV3Viewer__factory } from '@dopex-io/sdk';
 import format from 'date-fns/format';
-import useSendTx from 'hooks/useSendTx';
 import LockerIcon from 'svgs/icons/LockerIcon';
 import { useDebounce } from 'use-debounce';
 
 import { useBoundStore } from 'store';
 import { SsovV3EpochData } from 'store/Vault/ssov';
+
+import useSendTx from 'hooks/useSendTx';
 
 import EstimatedGasCostButton from 'components/common/EstimatedGasCostButton';
 import InputWithTokenSelector from 'components/common/InputWithTokenSelector';
@@ -63,11 +64,11 @@ const DepositPanel = () => {
   const [debouncedQuote] = useDebounce(quote, 1000);
   const [strikeDepositAmount, setStrikeDepositAmount] = useState<string>('0');
   const [userTokenBalance, setUserTokenBalance] = useState<BigNumber>(
-    BigNumber.from('0')
+    BigNumber.from('0'),
   );
   const [isTokenSelectorOpen, setTokenSelectorOpen] = useState(false);
   const [fromTokenSymbol, setFromTokenSymbol] = useState(
-    ssovData?.collateralSymbol ?? ''
+    ssovData?.collateralSymbol ?? '',
   );
 
   const { ssovContractWithSigner } = ssovSigner;
@@ -92,7 +93,7 @@ const DepositPanel = () => {
   ]);
 
   const strikes = epochStrikes.map((strike: BigNumber) =>
-    getUserReadableAmount(strike, 8).toString()
+    getUserReadableAmount(strike, 8).toString(),
   );
 
   const handleSelectStrike = useCallback((event: SelectChangeEvent<number>) => {
@@ -103,7 +104,7 @@ const DepositPanel = () => {
     (e: { target: { value: React.SetStateAction<string> } }) => {
       setStrikeDepositAmount(e.target.value);
     },
-    []
+    [],
   );
 
   const hasExpiryElapsed = useMemo(() => {
@@ -118,7 +119,7 @@ const DepositPanel = () => {
       await sendTx(
         ERC20__factory.connect(getContractAddress(fromTokenSymbol), signer),
         'approve',
-        [spender, ethersUtils.parseEther(strikeDepositAmount)]
+        [spender, ethersUtils.parseEther(strikeDepositAmount)],
       );
       setApproved(true);
     } catch (err) {
@@ -145,7 +146,7 @@ const DepositPanel = () => {
 
     const positions = await SsovV3Viewer__factory.connect(
       getSsovViewerAddress(),
-      signer
+      signer,
     ).walletOfOwner(accountAddress, ssovContractWithSigner.address);
     try {
       await sendTx(ssovStakingRewardsWithSigner, 'stake', [
@@ -166,8 +167,8 @@ const DepositPanel = () => {
 
     setUserTokenBalance(
       await ERC20__factory.connect(tokenAddress, signer).balanceOf(
-        accountAddress
-      )
+        accountAddress,
+      ),
     );
   }, [accountAddress, fromTokenSymbol, getContractAddress, signer]);
 
@@ -194,7 +195,7 @@ const DepositPanel = () => {
       Number(strikeDepositAmount) >
       getUserReadableAmount(
         userTokenBalance,
-        getTokenDecimals(fromTokenSymbol, chainId)
+        getTokenDecimals(fromTokenSymbol, chainId),
       )
     ) {
       disable = true;
@@ -249,11 +250,11 @@ const DepositPanel = () => {
 
     if (routerMode) {
       swapData = await get1inchSwap({
-        fromTokenAddress,
-        toTokenAddress,
-        amount: depositAmount,
         chainId,
-        accountAddress: ssovSigner.ssovRouterWithSigner?.address!,
+        src: fromTokenAddress,
+        dst: toTokenAddress,
+        amount: depositAmount.toString(),
+        from: ssovSigner.ssovRouterWithSigner?.address!,
       });
     }
 
@@ -335,7 +336,7 @@ const DepositPanel = () => {
 
       const allowance: BigNumber = await ERC20__factory.connect(
         tokenAddress,
-        signer
+        signer,
       ).allowance(accountAddress, spender);
 
       setApproved(allowance.gte(ethersUtils.parseEther(strikeDepositAmount)));
@@ -390,14 +391,13 @@ const DepositPanel = () => {
       return;
     setLoading(true);
 
-    await get1inchQuote(
-      fromTokenAddress,
-      toTokenAddress,
-      ethersUtils.parseEther(strikeDepositAmount).toString(),
+    await get1inchQuote({
       chainId,
-      accountAddress,
-      '3'
-    ).then((res) => {
+      src: fromTokenAddress,
+      dst: toTokenAddress,
+      amount: ethersUtils.parseEther(strikeDepositAmount).toString(),
+      from: accountAddress,
+    }).then((res) => {
       setQuote(res);
       setLoading(false);
       return res;
@@ -542,7 +542,7 @@ const DepositPanel = () => {
                     {epochTimes[1]
                       ? format(
                           new Date(epochTimes[1].toNumber() * 1000),
-                          'd LLL yyyy'
+                          'd LLL yyyy',
                         )
                       : '-'}
                   </Typography>
@@ -564,9 +564,9 @@ const DepositPanel = () => {
                       {formatAmount(
                         getUserReadableAmount(
                           BigNumber.from(debouncedQuote.toTokenAmount),
-                          debouncedQuote.toToken.decimals
+                          debouncedQuote.toToken.decimals,
                         ),
-                        3
+                        3,
                       )}{' '}
                       {ssovData?.collateralSymbol}~
                     </Typography>
@@ -591,7 +591,7 @@ const DepositPanel = () => {
                   {epochTimes[1]
                     ? format(
                         new Date(epochTimes[1].toNumber() * 1000),
-                        'd MMM yyyy HH:mm'
+                        'd MMM yyyy HH:mm',
                       )
                     : '-'}
                   )

--- a/apps/dapp/src/components/ssov/PurchaseDialog/index.tsx
+++ b/apps/dapp/src/components/ssov/PurchaseDialog/index.tsx
@@ -71,7 +71,7 @@ const PurchaseDialog = ({
 
   const [quoteDataLoading, setQuoteDataLoading] = useState(false);
   const [fromTokenSymbol, setFromTokenSymbol] = useState(
-    ssovData.collateralSymbol ?? ''
+    ssovData.collateralSymbol ?? '',
   );
   const [state, setState] = useState({
     volatility: 0,
@@ -87,7 +87,7 @@ const PurchaseDialog = ({
   const [strikeIndex, setStrikeIndex] = useState<number>(0);
   const [approved, setApproved] = useState<boolean>(false);
   const [userTokenBalance, setUserTokenBalance] = useState<BigNumber>(
-    BigNumber.from('0')
+    BigNumber.from('0'),
   );
   const [quote, setQuote] = useState({
     amountOut: BigNumber.from(0),
@@ -112,9 +112,9 @@ const PurchaseDialog = ({
         fromTokenSymbol !== ssovData.collateralSymbol
           ? quote.amountOut
           : state.totalCost,
-        getTokenDecimals(fromTokenSymbol, chainId)
+        getTokenDecimals(fromTokenSymbol, chainId),
       ),
-      5
+      5,
     );
   }, [
     chainId,
@@ -143,7 +143,7 @@ const PurchaseDialog = ({
   const strikes = useMemo(
     () =>
       epochStrikes.map((strike) => getUserReadableAmount(strike, 8).toString()),
-    [epochStrikes]
+    [epochStrikes],
   );
 
   const optionsAmount: number = useMemo(() => {
@@ -158,7 +158,7 @@ const PurchaseDialog = ({
     const finalAmount = state.totalCost;
     const _token = ERC20__factory.connect(
       getContractAddress(fromTokenSymbol),
-      provider
+      provider,
     );
 
     const allowance = await _token.allowance(accountAddress, spender);
@@ -215,21 +215,20 @@ const PurchaseDialog = ({
     const {
       toTokenAmount,
       toToken: { decimals },
-    } = await get1inchQuote(
-      fromTokenAddress,
-      toTokenAddress,
-      getContractReadableAmount(
-        1,
-        getTokenDecimals(fromTokenSymbol, chainId)
-      ).toString(),
+    } = await get1inchQuote({
       chainId,
-      accountAddress,
-      '3'
-    );
+      src: fromTokenAddress,
+      dst: toTokenAddress,
+      amount: getContractReadableAmount(
+        1,
+        getTokenDecimals(fromTokenSymbol, chainId),
+      ).toString(),
+      from: accountAddress,
+    });
 
     const collateralTokenDecimals = getTokenDecimals(
       ssovData.collateralSymbol,
-      chainId
+      chainId,
     );
 
     const fromTokenDecimals = getTokenDecimals(fromTokenSymbol, chainId);
@@ -241,7 +240,7 @@ const PurchaseDialog = ({
       multiplier = getContractReadableAmount(1, fromTokenDecimals);
       divisor = getContractReadableAmount(
         1,
-        collateralTokenDecimals - decimals
+        collateralTokenDecimals - decimals,
       );
     } else {
       multiplier = getContractReadableAmount(1, fromTokenDecimals);
@@ -258,11 +257,11 @@ const PurchaseDialog = ({
     }
 
     await get1inchSwap({
-      fromTokenAddress,
-      toTokenAddress,
-      amount: fromTokenAmountRequired,
+      src: fromTokenAddress,
+      dst: toTokenAddress,
+      amount: fromTokenAmountRequired.toString(),
       chainId,
-      accountAddress: ssovSigner.ssovRouterWithSigner.address,
+      from: ssovSigner.ssovRouterWithSigner.address,
     })
       .then((res: any) => {
         setQuote({
@@ -290,7 +289,7 @@ const PurchaseDialog = ({
       setIsPurchaseStatsLoading(true);
       setRawOptionsAmount(e.target.value);
     },
-    []
+    [],
   );
 
   const updateUserTokenBalance = useCallback(async () => {
@@ -302,8 +301,8 @@ const PurchaseDialog = ({
 
     setUserTokenBalance(
       await ERC20__factory.connect(tokenAddress, signer).balanceOf(
-        accountAddress
-      )
+        accountAddress,
+      ),
     );
   }, [accountAddress, fromTokenSymbol, getContractAddress, signer]);
 
@@ -350,7 +349,7 @@ const PurchaseDialog = ({
       await sendTx(
         ERC20__factory.connect(getContractAddress(fromTokenSymbol)!, signer),
         'approve',
-        [spender, MAX_VALUE]
+        [spender, MAX_VALUE],
       );
       setApproved(true);
     } catch (err) {
@@ -369,7 +368,7 @@ const PurchaseDialog = ({
 
     const _amount = getContractReadableAmount(
       optionsAmount,
-      OPTION_TOKEN_DECIMALS
+      OPTION_TOKEN_DECIMALS,
     );
 
     const contractWithSigner = routerMode
@@ -466,11 +465,11 @@ const PurchaseDialog = ({
           ssovContract.calculatePremium(
             strike!,
             getContractReadableAmount(1, 18),
-            expiry
+            expiry,
           ),
           ssovContract.calculatePurchaseFees(
             strike!,
-            getContractReadableAmount(debouncedOptionsAmount, 18)
+            getContractReadableAmount(debouncedOptionsAmount, 18),
           ),
         ]);
 
@@ -502,7 +501,7 @@ const PurchaseDialog = ({
             timeToExpirationInYears,
             volatility / 100,
             0,
-            isPut ? 'put' : 'call'
+            isPut ? 'put' : 'call',
           ),
         };
 
@@ -560,7 +559,7 @@ const PurchaseDialog = ({
               .div(getContractReadableAmount(strikes[strikeIndex]!, 8))
               .lt(getContractReadableAmount(optionsAmount, 18))
           : availableCollateralForStrike.lt(
-              getContractReadableAmount(optionsAmount, 18)
+              getContractReadableAmount(optionsAmount, 18),
             )) ||
         (isPut
           ? totalCost.gt(userTokenBalance)
@@ -568,7 +567,7 @@ const PurchaseDialog = ({
               .mul(1e8)
               .div(ssovData.collateralPrice!)
               .gt(userTokenBalance)) ||
-        quoteDataLoading
+        quoteDataLoading,
     );
 
     let onClick = () => {};
@@ -592,7 +591,7 @@ const PurchaseDialog = ({
               .div(getContractReadableAmount(strikes[strikeIndex]!, 8))
               .lt(getContractReadableAmount(optionsAmount, 18))
           : availableCollateralForStrikes[strikeIndex]!.lt(
-              getContractReadableAmount(optionsAmount, 18)
+              getContractReadableAmount(optionsAmount, 18),
             )
       ) {
         children = 'Collateral not available';
@@ -775,12 +774,12 @@ const PurchaseDialog = ({
                           ? formatAmount(
                               Number(strikes[strikeIndex]) -
                                 getUserReadableAmount(state.optionPrice, 8),
-                              5
+                              5,
                             )
                           : formatAmount(
                               Number(strikes[strikeIndex]) +
                                 getUserReadableAmount(state.optionPrice, 8),
-                              5
+                              5,
                             )}
                       </div>
                     </div>
@@ -795,17 +794,17 @@ const PurchaseDialog = ({
                           isPut
                             ? getUserReadableAmount(
                                 availableCollateralForStrikes[strikeIndex]!.div(
-                                  ssovEpochData.collateralExchangeRate
+                                  ssovEpochData.collateralExchangeRate,
                                 ),
-                                10
+                                10,
                               ) / Number(strikes[strikeIndex])
                             : getUserReadableAmount(
                                 availableCollateralForStrikes[strikeIndex]!.div(
-                                  ssovEpochData.collateralExchangeRate
+                                  ssovEpochData.collateralExchangeRate,
                                 ),
-                                10
+                                10,
                               ),
-                          5
+                          5,
                         )}
                       </div>
                     </div>
@@ -899,13 +898,13 @@ const PurchaseDialog = ({
                       isPut
                         ? getUserReadableAmount(
                             state.fees.mul(ssovData.lpPrice!),
-                            36
+                            36,
                           )
                         : getUserReadableAmount(
                             state.fees.mul(ssovData.collateralPrice!),
-                            26
+                            26,
                           ),
-                      5
+                      5,
                     )}
                   </>
                 )}

--- a/apps/dapp/src/components/straddles/PurchaseCard/index.tsx
+++ b/apps/dapp/src/components/straddles/PurchaseCard/index.tsx
@@ -3,7 +3,6 @@ import { BigNumber, ethers, utils as ethersUtils } from 'ethers';
 
 import Alert from '@mui/material/Alert';
 import CircularProgress from '@mui/material/CircularProgress';
-import Input from '@mui/material/Input';
 import Tooltip from '@mui/material/Tooltip';
 
 import {
@@ -22,6 +21,7 @@ import useSendTx from 'hooks/useSendTx';
 
 import EstimatedGasCostButton from 'components/common/EstimatedGasCostButton';
 import CustomButton from 'components/UI/Button';
+import Input from 'components/UI/Input';
 import NumberDisplay from 'components/UI/NumberDisplay';
 
 import { get1inchParams, get1inchSwap } from 'utils/1inch';
@@ -157,8 +157,8 @@ const PurchaseCard = () => {
       const currentPrice = await straddlesContract.getUnderlyingPrice();
 
       const amountOfUsdToSwap = currentPrice
-        .mul(amount)
-        .div(BigNumber.from('100'));
+        .mul(ethers.utils.parseUnits(String(amount), 8))
+        .div(BigNumber.from('10000000000'));
 
       const swap = await get1inchSwap({
         chainId: 137,
@@ -225,8 +225,8 @@ const PurchaseCard = () => {
         const currentPrice = await straddlesContract.getUnderlyingPrice();
 
         const amountOfUsdToSwap = currentPrice
-          .mul(amount)
-          .div(BigNumber.from('100'));
+          .mul(ethers.utils.parseUnits(String(amount), 8))
+          .div(BigNumber.from('10000000000'));
 
         const swap = await get1inchSwap({
           chainId: 137,
@@ -252,8 +252,8 @@ const PurchaseCard = () => {
           9,
         );
 
-        const minAmount = BigNumber.from(swap['toTokenAmount']).sub(
-          BigNumber.from(swap['toTokenAmount']).div(100),
+        const minAmount = BigNumber.from(swap['toAmount']).sub(
+          BigNumber.from(swap['toAmount']).div(100),
         );
 
         await sendTx(straddlesContract, 'purchase', [
@@ -386,7 +386,7 @@ const PurchaseCard = () => {
 
   return (
     <div>
-      <div className="bg-umbra rounded-2xl flex flex-col mb-4 p-3 pr-2">
+      <div className="bg-umbra rounded-2xl flex flex-col mb-4 px-3 pt-3 pr-2">
         <div className="flex flex-row justify-between">
           <div className="h-12 bg-cod-gray rounded-full pl-1 pr-1 pt-0 pb-0 flex flex-row items-center">
             <div className="flex flex-row h-10 w-[130px] p-1">
@@ -405,15 +405,14 @@ const PurchaseCard = () => {
             name="notionalSize"
             placeholder="0"
             type="number"
-            className="h-12 text-2xl text-white ml-2 mr-3 font-mono"
             value={rawAmount}
             onChange={(e) => setRawAmount(e.target.value)}
-            classes={{ input: 'text-right' }}
+            variant="straddles"
           />
         </div>
         <div className="my-1 w-full border-neutral-800">
           <div className="flex justify-between mx-2 pb-2 text-stieglitz text-sm">
-            <div>Max amount of straddles available:</div>
+            <div>Straddles Available:</div>
             <div>
               <NumberDisplay
                 n={maxStraddlesCanBeBought || BigNumber.from(0)}

--- a/apps/dapp/src/components/straddles/PurchaseCard/index.tsx
+++ b/apps/dapp/src/components/straddles/PurchaseCard/index.tsx
@@ -85,13 +85,13 @@ const PurchaseCard = () => {
   const { isLoading, error, data } = useQuery(
     ['currentPrice'],
     () => straddlesData?.straddlesContract?.getUnderlyingPrice(),
-    { initialData: oneEBigNumber(8) }
+    { initialData: oneEBigNumber(8) },
   );
 
   const [finalCost, setFinalCost] = useState(BigNumber.from(0));
 
   const [userTokenBalance, setUserTokenBalance] = useState<BigNumber>(
-    BigNumber.from('0')
+    BigNumber.from('0'),
   );
 
   const maxStraddlesCanBeBought = useMemo(() => {
@@ -99,8 +99,8 @@ const PurchaseCard = () => {
 
     const availableUsdDeposits = straddlesEpochData?.usdDeposits.sub(
       BigNumber.from(straddlesEpochData?.activeUsdDeposits).div(
-        '100000000000000000000'
-      )
+        '100000000000000000000',
+      ),
     );
 
     if (!availableUsdDeposits) return BigNumber.from(0);
@@ -134,7 +134,7 @@ const PurchaseCard = () => {
           getContractReadableAmount(2 * amount, 18),
           0,
           POOL_TO_SWAPPER_IDS[selectedPoolName]!,
-          accountAddress
+          accountAddress,
         );
 
       setFinalCost(data.protocolFee.add(data.straddleCost));
@@ -151,7 +151,7 @@ const PurchaseCard = () => {
 
       const straddlesContract = AtlanticStraddleV2__factory.connect(
         Addresses[137]['STRADDLES'].Vault['MATIC'],
-        signer
+        signer,
       );
 
       const currentPrice = await straddlesContract.getUnderlyingPrice();
@@ -161,11 +161,11 @@ const PurchaseCard = () => {
         .div(BigNumber.from('100'));
 
       const swap = await get1inchSwap({
-        fromTokenAddress: straddlesData.usd,
-        toTokenAddress: straddlesData.underlying,
-        amount: amountOfUsdToSwap,
         chainId: 137,
-        accountAddress: straddlesContract.address,
+        src: straddlesData.usd,
+        dst: straddlesData.underlying,
+        amount: amountOfUsdToSwap.toString(),
+        from: straddlesContract.address,
       });
 
       try {
@@ -175,7 +175,7 @@ const PurchaseCard = () => {
           0,
           accountAddress,
           //@ts-ignore
-          purchaseParams
+          purchaseParams,
         );
 
         const protocolFee = results[1];
@@ -219,7 +219,7 @@ const PurchaseCard = () => {
       if (chainId === 137) {
         const straddlesContract = AtlanticStraddleV2__factory.connect(
           Addresses[137]['STRADDLES'].Vault['MATIC'],
-          signer
+          signer,
         );
 
         const currentPrice = await straddlesContract.getUnderlyingPrice();
@@ -229,31 +229,31 @@ const PurchaseCard = () => {
           .div(BigNumber.from('100'));
 
         const swap = await get1inchSwap({
-          fromTokenAddress: straddlesData.usd,
-          toTokenAddress: straddlesData.underlying,
-          amount: amountOfUsdToSwap,
           chainId: 137,
-          accountAddress: straddlesData.straddlesContract.address,
+          src: straddlesData.usd,
+          dst: straddlesData.underlying,
+          amount: amountOfUsdToSwap.toString(),
+          from: straddlesData.straddlesContract.address,
         });
 
         const { purchaseParams } = get1inchParams(swap['tx']['data']);
 
         const { data } = await axios.get(
-          `https://gasstation-mainnet.matic.network/v2`
+          `https://gasstation-mainnet.matic.network/v2`,
         );
 
         const maxFeePerGas = ethers.utils.parseUnits(
           data['fast']['maxFee'].toFixed(9),
-          9
+          9,
         );
 
         const maxPriorityFeePerGas = ethers.utils.parseUnits(
           data['fast']['maxPriorityFee'].toFixed(9),
-          9
+          9,
         );
 
         const minAmount = BigNumber.from(swap['toTokenAmount']).sub(
-          BigNumber.from(swap['toTokenAmount']).div(100)
+          BigNumber.from(swap['toTokenAmount']).div(100),
         );
 
         await sendTx(straddlesContract, 'purchase', [
@@ -277,7 +277,7 @@ const PurchaseCard = () => {
             0,
             POOL_TO_SWAPPER_IDS[selectedPoolName]!,
             accountAddress,
-          ]
+          ],
         );
       }
       await updateStraddlesUserData();
@@ -305,7 +305,7 @@ const PurchaseCard = () => {
       await sendTx(
         ERC20__factory.connect(straddlesData.usd, signer),
         'approve',
-        [straddlesData.straddlesContract.address, MAX_VALUE]
+        [straddlesData.straddlesContract.address, MAX_VALUE],
       );
       setApproved(true);
     } catch (err) {
@@ -358,7 +358,7 @@ const PurchaseCard = () => {
       const token = ERC20__factory.connect(straddlesData.usd, signer);
       const allowance: BigNumber = await token.allowance(
         accountAddress,
-        straddlesData?.straddlesContract?.address
+        straddlesData?.straddlesContract?.address,
       );
       const balance: BigNumber = await token.balanceOf(accountAddress);
       setApproved(allowance.gte(finalAmount));

--- a/apps/dapp/src/components/straddles/PurchaseCard/index.tsx
+++ b/apps/dapp/src/components/straddles/PurchaseCard/index.tsx
@@ -239,7 +239,7 @@ const PurchaseCard = () => {
         const { purchaseParams } = get1inchParams(swap['tx']['data']);
 
         const { data } = await axios.get(
-          `https://gasstation-mainnet.matic.network/v2`,
+          `https://gasstation.polygon.technology/v2`,
         );
 
         const maxFeePerGas = ethers.utils.parseUnits(

--- a/apps/dapp/src/utils/1inch/get1inchQuote.ts
+++ b/apps/dapp/src/utils/1inch/get1inchQuote.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+import { DOPEX_API_BASE_URL } from 'constants/env';
+
 export interface TokenData {
   address: string;
   decimals: number;
@@ -47,19 +49,25 @@ export const defaultQuoteData: I1inchQuote = {
   toTokenAmount: '0',
 };
 
-const get1inchQuote = async (
-  fromTokenAddress: string,
-  toTokenAddress: string,
-  amount: string,
-  chainId: number,
-  accountAddress: string,
-  slippage: string
-): Promise<I1inchQuote> => {
-  if (fromTokenAddress === toTokenAddress || amount === '' || amount === '0')
-    return defaultQuoteData;
+interface Args {
+  chainId: number;
+  src: string;
+  dst: string;
+  amount: string;
+  from: string;
+}
+
+const get1inchQuote = async ({
+  chainId,
+  src,
+  dst,
+  amount,
+  from,
+}: Args): Promise<I1inchQuote> => {
+  if (src === dst || amount === '' || amount === '0') return defaultQuoteData;
 
   const { data } = await axios.get(
-    `https://api.1inch.exchange/v5.0/${chainId}/quote?fromTokenAddress=${fromTokenAddress}&toTokenAddress=${toTokenAddress}&amount=${amount}&fromAddress=${accountAddress}&slippage=${slippage}&disableEstimate=true`
+    `${DOPEX_API_BASE_URL}/v2/1inch/quote?chainId=${chainId}&src=${src}&dst=${dst}&amount=${amount}&from=${from}`,
   );
 
   return data;

--- a/apps/dapp/src/utils/1inch/get1inchSwap.ts
+++ b/apps/dapp/src/utils/1inch/get1inchSwap.ts
@@ -1,25 +1,19 @@
-import { BigNumber } from 'ethers';
-
 import axios from 'axios';
 
+import { DOPEX_API_BASE_URL } from 'constants/env';
+
 interface Args {
-  fromTokenAddress: string;
-  toTokenAddress: string;
-  amount: BigNumber;
   chainId: number;
-  accountAddress: string;
+  src: string;
+  dst: string;
+  amount: string;
+  from: string;
 }
 
-const get1inchSwap = async ({
-  fromTokenAddress,
-  toTokenAddress,
-  amount,
-  chainId,
-  accountAddress,
-}: Args) => {
+const get1inchSwap = async ({ chainId, src, dst, amount, from }: Args) => {
   try {
     const { data } = await axios.get(
-      `https://api.1inch.exchange/v5.0/${chainId}/swap?fromTokenAddress=${fromTokenAddress}&toTokenAddress=${toTokenAddress}&amount=${amount.toString()}&fromAddress=${accountAddress}&slippage=0&disableEstimate=true&compatibilityMode=true`
+      `${DOPEX_API_BASE_URL}/v2/1inch/swap?chainId=${chainId}&src=${src}&dst=${dst}&amount=${amount}&from=${from}`,
     );
     return data;
   } catch {


### PR DESCRIPTION
<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope

<!-- Brief description of WHAT you’re doing and WHY. -->

Fixes 1inch API calls since they added auth requirements

## Implementation

Use the Dopex API to delegate 1inch api calls using auth requirements

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

N/A

## How to Test

<!--

A straightforward scenario of how to test your changes could help colleagues that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

MATIC Straddle purchasing should work as normal