### PR TITLE
fix(ssov-beta): breakeven calculation

### DIFF
--- a/apps/dapp/src/components/ssov-beta/AsidePanel/index.tsx
+++ b/apps/dapp/src/components/ssov-beta/AsidePanel/index.tsx
@@ -479,23 +479,7 @@ const AsidePanel = ({ market }: { market: string }) => {
       </div>
       <div className="bg-cod-gray p-3 rounded-lg">
         <PnlChart
-          breakEven={
-            vault.isPut
-              ? Number(selectedStrike.strike) -
-                Number(
-                  formatUnits(
-                    selectedStrike.premiumPerOption || 0n,
-                    DECIMALS_TOKEN,
-                  ),
-                )
-              : Number(selectedStrike.strike) +
-                Number(
-                  formatUnits(
-                    selectedStrike.premiumPerOption || 0n,
-                    DECIMALS_TOKEN,
-                  ),
-                )
-          }
+          breakEven={selectedStrike.breakeven}
           optionPrice={Number(
             formatUnits(selectedStrike.premiumPerOption || 0n, DECIMALS_TOKEN),
           )}

--- a/apps/dapp/src/components/ssov-beta/Tables/StrikesChain/StrikeTable.tsx
+++ b/apps/dapp/src/components/ssov-beta/Tables/StrikesChain/StrikeTable.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { Address, formatUnits } from 'viem';
 
-import { Button, Disclosure, Menu, Skeleton } from '@dopex-io/ui';
+import { Button /* Menu,*/, Disclosure, Skeleton } from '@dopex-io/ui';
 import { MinusCircleIcon, PlusCircleIcon } from '@heroicons/react/24/outline';
 import {
   ChevronDownIcon,
@@ -334,7 +334,7 @@ const StrikesTable = ({ market }: { market: string }) => {
   }, []);
 
   const strikeData = useMemo(() => {
-    if (!strikesData) return [];
+    if (!strikesData || !selectedVault) return [];
 
     return strikesData.map((strikeData, index) => {
       const premiumFormatted = Number(
@@ -357,12 +357,15 @@ const StrikesTable = ({ market }: { market: string }) => {
 
       premiumApy = premiumApy * (365 / (vault.duration === 'WEEKLY' ? 7 : 30));
 
+      const premiumInUSD =
+        (selectedVault.isPut ? 1 : Number(selectedVault.currentPrice)) *
+        premiumFormatted;
+
       return {
         strike: strikeData.strike,
         breakeven: (vault.isPut
-          ? strikeData.strike - premiumFormatted
-          : strikeData.strike +
-            premiumFormatted * Number(selectedVault?.currentPrice)
+          ? strikeData.strike - premiumInUSD
+          : strikeData.strike + premiumInUSD
         ).toFixed(3),
         availableCollateral: {
           strike: strikeData.strike,
@@ -396,8 +399,7 @@ const StrikesTable = ({ market }: { market: string }) => {
     });
   }, [
     strikesData,
-    selectedVault?.currentPrice,
-    selectedVault?.apy,
+    selectedVault,
     vault.duration,
     vault.isPut,
     vault.underlyingSymbol,


### PR DESCRIPTION
<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope

Fix incorrect breakeven values across the SSOV Beta page.


## Implementation

With @pair

Breakeven calculation for calls didn't account for underlying price.

## Screenshots

|         | before | after |
| ------- | ------ | ----- |
| desktop |  ![image](https://github.com/dopex-io/elvarg/assets/85767768/ffc2a32c-5b27-431f-bf1d-e741bf001090)   | <img width="1343" alt="Screenshot 2023-08-14" src="https://github.com/dopex-io/elvarg/assets/85767768/a96ea9c5-bf5f-4b37-81cd-f0273b9921e7">   |
| mobile  |        |       |

## How to Test

Test breakeven prices for both puts and calls, across different markets. Use the following formula:

```
PUT: breakeven = strike - premiumInUSD
CALL: breakeven = strike + premiumInUSD
```