### PR TITLE
fix(ssov-new): expiry pill ordering & input width (DOP-462)

### DIFF
--- a/apps/dapp/src/components/ssov-beta/AsidePanel/index.tsx
+++ b/apps/dapp/src/components/ssov-beta/AsidePanel/index.tsx
@@ -64,6 +64,28 @@ export const ButtonGroup = ({
   );
 };
 
+const UserBalance = ({
+  symbol,
+  userBalance,
+  ...rest
+}: React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLDivElement>,
+  HTMLDivElement
+> & {
+  symbol: string | undefined;
+  userBalance: bigint;
+}) => (
+  <div className="flex justify-between text-xs text-stieglitz px-1" {...rest}>
+    <p>Balance</p>
+    <span className="flex">
+      <p className="text-white pr-1">
+        {formatAmount(formatUnits(userBalance, DECIMALS_TOKEN), 3, true)}
+      </p>
+      {symbol || ''}
+    </span>
+  </div>
+);
+
 const AsidePanel = ({ market }: { market: string }) => {
   const [amount, setAmount] = useState<string>('0');
   const [activeIndex, setActiveIndex] = useState<number>(0);
@@ -354,6 +376,10 @@ const AsidePanel = ({ market }: { market: string }) => {
             />
           }
           placeholder="0.0"
+        />
+        <UserBalance
+          symbol={collateralTokenReads.data?.[0].result as string}
+          userBalance={userBalance}
         />
         {infoPopover.textContent !== '' ? (
           <div

--- a/apps/dapp/src/components/ssov-beta/AsidePanel/index.tsx
+++ b/apps/dapp/src/components/ssov-beta/AsidePanel/index.tsx
@@ -78,7 +78,7 @@ const UserBalance = ({
   <div className="flex justify-between text-xs text-stieglitz px-1" {...rest}>
     <p>Balance</p>
     <span className="flex">
-      <p className="text-white pr-1">
+      <p className="text-white pr-1 underline decoration-dashed">
         {formatAmount(formatUnits(userBalance, DECIMALS_TOKEN), 3, true)}
       </p>
       {symbol || ''}
@@ -191,6 +191,10 @@ const AsidePanel = ({ market }: { market: string }) => {
     setActiveIndex(index);
   };
 
+  const handleMax = useCallback(() => {
+    setAmount(formatUnits(userBalance, DECIMALS_TOKEN).toString());
+  }, [userBalance]);
+
   const handleChange = useCallback(
     (e: { target: { value: SetStateAction<any> } }) => {
       setAmount(e.target.value);
@@ -281,7 +285,8 @@ const AsidePanel = ({ market }: { market: string }) => {
     const totalFees = Number(
       formatUnits(
         selectedVault.isPut
-          ? selectedStrike.purchaseFeePerOption * BigInt(amountDebounced)
+          ? selectedStrike.purchaseFeePerOption *
+              parseUnits(amountDebounced, DECIMALS_TOKEN)
           : (selectedStrike.purchaseFeePerOption *
               parseUnits(amountDebounced, DECIMALS_TOKEN) *
               parseUnits(selectedVault.currentPrice, DECIMALS_USD)) /
@@ -380,6 +385,8 @@ const AsidePanel = ({ market }: { market: string }) => {
         <UserBalance
           symbol={collateralTokenReads.data?.[0].result as string}
           userBalance={userBalance}
+          role="button"
+          onClick={handleMax}
         />
         {infoPopover.textContent !== '' ? (
           <div

--- a/apps/dapp/src/constants/ssov/markets.ts
+++ b/apps/dapp/src/constants/ssov/markets.ts
@@ -20,20 +20,20 @@ export const MARKETS: { [key: string]: SsovMarket } = {
   STETH: {
     vaults: [
       {
-        symbol: 'stETH-MONTHLY-CALLS-SSOV-V3',
-        isPut: false,
-        duration: 'MONTHLY',
-        underlyingSymbol: 'stETH',
-        collateralTokenAddress: '0x5979D7b546E38E414F7E9822514be443A4800529',
-        address: '0x475a5a712b741b9ab992e6af0b9e5adee3d1851b',
-      },
-      {
         symbol: 'stETH-WEEKLY-CALLS-SSOV-V3',
         isPut: false,
         duration: 'WEEKLY',
         underlyingSymbol: 'stETH',
         collateralTokenAddress: '0x5979D7b546E38E414F7E9822514be443A4800529',
         address: '0xFca61E79F38a7a82c62f469f55A9df54CB8dF678',
+      },
+      {
+        symbol: 'stETH-MONTHLY-CALLS-SSOV-V3',
+        isPut: false,
+        duration: 'MONTHLY',
+        underlyingSymbol: 'stETH',
+        collateralTokenAddress: '0x5979D7b546E38E414F7E9822514be443A4800529',
+        address: '0x475a5a712b741b9ab992e6af0b9e5adee3d1851b',
       },
     ],
     default: {

--- a/packages/ui/src/Input.tsx
+++ b/packages/ui/src/Input.tsx
@@ -67,7 +67,7 @@ const Input = (props: InputProps) => {
       className={cx(
         variants[variant].box,
         bgColors[color],
-        `${outline ? `border border-${outline}` : 'border-0'}`
+        `${outline ? `border border-${outline}` : 'border-0'}`,
       )}
     >
       <div className="flex justify-between">
@@ -78,7 +78,7 @@ const Input = (props: InputProps) => {
             variants[variant].textPosition,
             variants[variant].font,
             bgColors[color],
-            'text-white text-right w-1/3 focus:outline-none'
+            'text-white text-right w-2/3 focus:outline-none',
           )}
           placeholder={placeholder}
           onChange={onChange}


### PR DESCRIPTION
## Scope

The expiry pills in stETH ssovs are inconsistent with other markets. The intended order is weeklies to the left and monthlies to the right.

Some additional changes made in this PR:
- Increase width of Input component in dopex-io/ui
- Allow users to view their balance and click on their balance to input their entire balance
- Page-crashing bug caused by decimal value in input panel when user toggles between ssov side or expiry.

cc. [DOP-462](https://linear.app/dopex/issue/DOP-462/show-token-balance-on-the-ui), [DOP-464](https://linear.app/dopex/issue/DOP-464/input-box-only-display-the-first-6-digits)

## Implementation

Changed the constants/ssov/markets.ts config for stETH

## Screenshots

|         | before | after |
| ------- | ------ | ----- |
| desktop |   <img width="285" alt="Screenshot 2023-08-14" src="https://github.com/dopex-io/elvarg/assets/85767768/c2759d0f-1638-493a-93c3-c3fa7978d6b6">    |  <img width="312" alt="Screenshot 2023-08-14" src="https://github.com/dopex-io/elvarg/assets/85767768/29630394-9558-4880-b178-5af6bed696ac">    |
| mobile  |        |       |

## How to Test

- Switch from ARB to STETH in the dropdown menu on top of the page. Then note the ordering of pills in the table that displays strikes.
- Enter a large value in the input panel to view a larger number at a time before overflow
- View and click your balance under the input box inside the panel on the right-hand side of the page
- Enter a value in the right-hand side panel that contains decimals, then change the ssov to PUT/CALL MONTHLY/WEEKLY inside the strikes table.