### PR TITLE
refactor: basic table layout

### DIFF
--- a/apps/dapp/src/components/common/TableLayout/index.tsx
+++ b/apps/dapp/src/components/common/TableLayout/index.tsx
@@ -1,0 +1,104 @@
+import {
+  AccessorKeyColumnDef,
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+
+import Placeholder from 'components/ssov-beta/Tables/Placeholder';
+
+interface Props<T> {
+  data: T[];
+  columns: (ColumnDef<T, any> | AccessorKeyColumnDef<T>)[];
+  isContentLoading: boolean;
+}
+
+const TableLayout = <T extends object>({
+  data,
+  columns,
+  isContentLoading,
+}: Props<T>) => {
+  const table = useReactTable({
+    columns,
+    data,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  const { getHeaderGroups, getRowModel } = table;
+
+  return data.length > 0 ? (
+    <div className="space-y-2 bg-cod-gray rounded-lg py-3">
+      <div className="overflow-x-auto">
+        <table className="bg-cod-gray rounded-lg w-full">
+          <thead className="sticky">
+            {getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header, index: number) => {
+                  let textAlignment;
+                  if (index === 0) {
+                    textAlignment = 'text-left';
+                  } else if (index === columns.length - 1) {
+                    textAlignment = 'text-right';
+                  } else {
+                    textAlignment = 'text-left';
+                  }
+                  return (
+                    <th
+                      key={header.id}
+                      className={`m-3 py-1 px-4 ${textAlignment} w-1/${columns.length}`}
+                    >
+                      <span className="text-sm text-stieglitz font-normal">
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext(),
+                            )}
+                      </span>
+                    </th>
+                  );
+                })}
+              </tr>
+            ))}
+          </thead>
+          <tbody className="max-h-32 overflow-y-auto">
+            {getRowModel().rows.map((row) => {
+              return (
+                <tr key={row.id} className={`border-b border-umbra`}>
+                  {row.getVisibleCells().map((cell, index) => {
+                    let textAlignment;
+                    if (index === 0) {
+                      textAlignment = 'text-left';
+                    } else if (index === columns.length - 1) {
+                      textAlignment = 'text-right';
+                    } else {
+                      textAlignment = 'text-left';
+                    }
+                    return (
+                      <td
+                        key={cell.id}
+                        className={`m-3 py-2 px-4 ${textAlignment}`}
+                      >
+                        <span className="text-sm">
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
+                          )}
+                        </span>
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  ) : (
+    <Placeholder isLoading={isContentLoading} />
+  );
+};
+
+export default TableLayout;

--- a/apps/dapp/src/components/ssov-beta/Tables/Positions/BuyPositions.tsx
+++ b/apps/dapp/src/components/ssov-beta/Tables/Positions/BuyPositions.tsx
@@ -2,12 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { Address, formatUnits, parseUnits } from 'viem';
 
 import { Button } from '@dopex-io/ui';
-import {
-  createColumnHelper,
-  flexRender,
-  getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+import { createColumnHelper } from '@tanstack/react-table';
 import format from 'date-fns/format';
 import Countdown from 'react-countdown';
 import { useAccount } from 'wagmi';
@@ -16,8 +11,8 @@ import { BuyPosition } from 'hooks/ssov/useSsovPositions';
 import useVaultsData from 'hooks/ssov/useVaultsData';
 import useVaultStore from 'hooks/ssov/useVaultStore';
 
+import TableLayout from 'components/common/TableLayout';
 import SettleStepper from 'components/ssov-beta/Dialogs/SettleStepper';
-import Placeholder from 'components/ssov-beta/Tables/Placeholder';
 
 import { STRIKE_DECIMALS } from 'utils/contracts/atlantics/pool';
 import { formatAmount } from 'utils/general';
@@ -201,91 +196,13 @@ const BuyPositions = (props: Props) => {
     selectedVault?.currentPrice,
   ]);
 
-  const table = useReactTable({
-    columns,
-    data: positions,
-    getCoreRowModel: getCoreRowModel(),
-  });
-
-  const { getHeaderGroups, getRowModel } = table;
-
   return (
     <div className="space-y-2">
-      {positions.length > 0 ? (
-        <div className="space-y-2 bg-cod-gray rounded-lg py-3">
-          <div className="overflow-x-auto">
-            <table className="bg-cod-gray rounded-lg w-full">
-              <thead className="sticky">
-                {getHeaderGroups().map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers.map((header, index: number) => {
-                      let textAlignment;
-                      if (index === 0) {
-                        textAlignment = 'text-left';
-                      } else if (index === columns.length - 1) {
-                        textAlignment = 'text-right';
-                      } else {
-                        textAlignment = 'text-left';
-                      }
-                      return (
-                        <th
-                          key={header.id}
-                          className={`m-3 py-1 px-4 ${textAlignment} w-1/${columns.length}`}
-                        >
-                          <span className="text-sm text-stieglitz font-normal">
-                            {header.isPlaceholder
-                              ? null
-                              : flexRender(
-                                  header.column.columnDef.header,
-                                  header.getContext(),
-                                )}
-                          </span>
-                        </th>
-                      );
-                    })}
-                  </tr>
-                ))}
-              </thead>
-              <tbody className="max-h-32 overflow-y-auto">
-                {getRowModel().rows.map((row) => {
-                  return (
-                    <tr
-                      key={row.id}
-                      className={`hover:bg-umbra border-b border-umbra`}
-                    >
-                      {row.getVisibleCells().map((cell, index) => {
-                        let textAlignment;
-                        if (index === 0) {
-                          textAlignment = 'text-left';
-                        } else if (index === columns.length - 1) {
-                          textAlignment = 'text-right';
-                        } else {
-                          textAlignment = 'text-left';
-                        }
-                        return (
-                          <td
-                            key={cell.id}
-                            className={`m-3 py-2 px-4 ${textAlignment}`}
-                          >
-                            <span className="text-sm">
-                              {flexRender(
-                                cell.column.columnDef.cell,
-                                cell.getContext(),
-                              )}
-                            </span>
-                          </td>
-                        );
-                      })}
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      ) : (
-        <Placeholder isLoading={isLoading} />
-      )}
+      <TableLayout<BuyPositionData>
+        data={positions}
+        columns={columns}
+        isContentLoading={isLoading}
+      />
       <SettleStepper
         isOpen={open}
         handleClose={handleClose}

--- a/apps/dapp/src/components/ssov-beta/Tables/Positions/WritePositions.tsx
+++ b/apps/dapp/src/components/ssov-beta/Tables/Positions/WritePositions.tsx
@@ -2,12 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { Address, formatUnits, zeroAddress } from 'viem';
 
 import { Button } from '@dopex-io/ui';
-import {
-  createColumnHelper,
-  flexRender,
-  getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+import { createColumnHelper } from '@tanstack/react-table';
 import format from 'date-fns/format';
 import Countdown from 'react-countdown';
 import { useAccount } from 'wagmi';
@@ -16,8 +11,8 @@ import { RewardAccrued, WritePosition } from 'hooks/ssov/useSsovPositions';
 import useVaultsData from 'hooks/ssov/useVaultsData';
 import useVaultStore from 'hooks/ssov/useVaultStore';
 
+import TableLayout from 'components/common/TableLayout';
 import WithdrawStepper from 'components/ssov-beta/Dialogs/WithdrawStepper';
-import Placeholder from 'components/ssov-beta/Tables/Placeholder';
 
 import { formatAmount } from 'utils/general';
 
@@ -254,91 +249,13 @@ const WritePositions = (props: Props) => {
     });
   }, [_positions, vault.underlyingSymbol, selectedVault?.currentEpoch]);
 
-  const table = useReactTable({
-    columns,
-    data: positions,
-    getCoreRowModel: getCoreRowModel(),
-  });
-
-  const { getHeaderGroups, getRowModel } = table;
-
   return (
     <div className="space-y-2">
-      {positions.length > 0 ? (
-        <div className="space-y-2 bg-cod-gray rounded-lg py-3">
-          <div className="overflow-x-auto">
-            <table className="bg-cod-gray rounded-lg w-full">
-              <thead className="sticky">
-                {getHeaderGroups().map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers.map((header, index: number) => {
-                      let textAlignment;
-                      if (index === 0) {
-                        textAlignment = 'text-left';
-                      } else if (index === columns.length - 1) {
-                        textAlignment = 'text-right';
-                      } else {
-                        textAlignment = 'text-left';
-                      }
-                      return (
-                        <th
-                          key={header.id}
-                          className={`m-3 py-2 px-3 ${textAlignment} w-1/${columns.length}`}
-                        >
-                          <span className="text-sm text-stieglitz font-normal">
-                            {header.isPlaceholder
-                              ? null
-                              : flexRender(
-                                  header.column.columnDef.header,
-                                  header.getContext(),
-                                )}{' '}
-                          </span>
-                        </th>
-                      );
-                    })}
-                  </tr>
-                ))}
-              </thead>
-              <tbody className="max-h-32 overflow-y-auto">
-                {getRowModel().rows.map((row) => {
-                  return (
-                    <tr
-                      key={row.id}
-                      className="hover:bg-umbra border-b border-umbra"
-                    >
-                      {row.getVisibleCells().map((cell, index) => {
-                        let textAlignment;
-                        if (index === 0) {
-                          textAlignment = 'text-left';
-                        } else if (index === columns.length - 1) {
-                          textAlignment = 'text-right';
-                        } else {
-                          textAlignment = 'text-left';
-                        }
-                        return (
-                          <td
-                            key={cell.id}
-                            className={`m-3 py-2 px-3 ${textAlignment}`}
-                          >
-                            <span className="text-sm">
-                              {flexRender(
-                                cell.column.columnDef.cell,
-                                cell.getContext(),
-                              )}{' '}
-                            </span>
-                          </td>
-                        );
-                      })}
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      ) : (
-        <Placeholder isLoading={isLoading} />
-      )}
+      <TableLayout<WritePositionData>
+        data={positions}
+        columns={columns}
+        isContentLoading={isLoading}
+      />
       <WithdrawStepper
         isOpen={open}
         handleClose={handleClose}


### PR DESCRIPTION
## Scope

A reusable table layout to construct basic tables using tanstack/react-tables v8.

## Implementation

The interface for the props of the TableLayout component takes a generic type that is passed from the child table. The table is constructed based on the shape of the object passed. The columns must still defined inside the child component. 

## Screenshots
 
N/A

## How to Test

N/A. Please review the code carefully as well as the typings in the TableLayout common component as well as all its instances. 

References:
[React table v8](https://tanstack.com/table/v8)
[An argument against usage of 'any' type for this scenario](https://github.com/TanStack/table/issues/4241)