### PR TITLE
fix(ssov-beta): insufficient balance bug

### DIFF
--- a/apps/dapp/src/components/ssov-beta/AsidePanel/index.tsx
+++ b/apps/dapp/src/components/ssov-beta/AsidePanel/index.tsx
@@ -259,7 +259,13 @@ const AsidePanel = ({ market }: { market: string }) => {
   }, [amountDebounced, selectedStrike, selectedVault]);
 
   const infoPopover = useMemo(() => {
-    const buttonContent = activeIndex === 0 ? 'Purchase' : 'Deposit';
+    const isLong = activeIndex === 0;
+    const buttonContent = isLong ? 'Purchase' : 'Deposit';
+    const insufficientBalance = isLong
+      ? Number(formatUnits(userBalance, DECIMALS_TOKEN)) <
+        Number(panelData.totalCost) / Number(selectedVault?.currentPrice || 1)
+      : userBalance < parseUnits(amountDebounced || '0', DECIMALS_TOKEN);
+
     if (!selectedVault || !collateralTokenReads.data || !approveConfig.result)
       return {
         ...alerts.error.fallback,
@@ -279,10 +285,7 @@ const AsidePanel = ({ market }: { market: string }) => {
       return {
         ...alerts.info.insufficientLiquidity,
       };
-    else if (
-      Number(formatUnits(userBalance, DECIMALS_TOKEN)) <
-      Number(panelData.totalCost) / Number(selectedVault?.currentPrice || 1)
-    )
+    else if (insufficientBalance)
       return {
         ...alerts.error.insufficientBalance,
         buttonContent,

--- a/apps/dapp/src/components/ssov-beta/AsidePanel/index.tsx
+++ b/apps/dapp/src/components/ssov-beta/AsidePanel/index.tsx
@@ -279,7 +279,10 @@ const AsidePanel = ({ market }: { market: string }) => {
       return {
         ...alerts.info.insufficientLiquidity,
       };
-    else if (userBalance < parseUnits(amountDebounced || '0', DECIMALS_TOKEN))
+    else if (
+      Number(formatUnits(userBalance, DECIMALS_TOKEN)) <
+      Number(panelData.totalCost) / Number(selectedVault?.currentPrice || 1)
+    )
       return {
         ...alerts.error.insufficientBalance,
         buttonContent,
@@ -309,6 +312,7 @@ const AsidePanel = ({ market }: { market: string }) => {
     selectedStrike.iv,
     userBalance,
     approved,
+    panelData.totalCost,
   ]);
 
   const renderCondition = useMemo(() => {


### PR DESCRIPTION
in panel textfield

## Scope

The Insufficient Balance popup makes an incorrect check. It checks for input amount against user's balance. But it should check total cost in underlying against user balance for the same collateral.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

|         | before | after |
| ------- | ------ | ----- |
| desktop |    <img width="318" alt="Screenshot 2023-08-20 at 4 30 35 PM" src="https://github.com/dopex-io/elvarg/assets/85767768/4cdf6bfa-e7c9-41c0-a9a5-d0e9d964cdc7">    |   <img width="322" alt="Screenshot 2023-08-20 at 4 29 59 PM" src="https://github.com/dopex-io/elvarg/assets/85767768/c0f694c4-37c6-4dd6-89ae-f9cfa4d27768">    |
| mobile  |        |       |

## How to Test

Check if the 'Insufficient Balance' popup changes to 'Insufficient Allowance' (if you provided insufficient allowance), another popup, or no popup altogether when cost for options exceeds user collateral balance.
