### PR TITLE
fix(ssov-beta): disclosure content alignment

### DIFF
--- a/apps/dapp/src/components/ssov-beta/Tables/StrikesChain/StrikeTable.tsx
+++ b/apps/dapp/src/components/ssov-beta/Tables/StrikesChain/StrikeTable.tsx
@@ -58,7 +58,7 @@ interface StrikeItem {
 }
 
 const StatItem = ({ name, value }: { name: string; value: string }) => (
-  <div className="flex flex-col">
+  <div className="flex flex-col px-1">
     <span className="text-sm font-medium">{value}</span>
     <span className="text-stieglitz text-xs">{name}</span>
   </div>
@@ -67,8 +67,8 @@ const StatItem = ({ name, value }: { name: string; value: string }) => (
 const TableDisclosure = (props: DisclosureStrikeItem) => {
   return (
     <Disclosure.Panel as="tr" className="bg-umbra">
-      <td colSpan={5}>
-        <div className="grid grid-cols-5 gap-6 p-3">
+      <td colSpan={4}>
+        <div className="grid grid-cols-4 gap-6 p-3">
           <StatItem name="IV" value={String(props.iv)} />
           <StatItem name="Delta" value={formatAmount(props.delta, 5)} />
           <StatItem name="Vega" value={formatAmount(props.vega, 5)} />


### PR DESCRIPTION
## Scope

Align the disclosure items with parent row in the SSOV's option chain.

## Implementation

Reduce number of columns from 5 to 4, and add appropriate padding based on parent's td element.

## Screenshots

|         | before | after |
| ------- | ------ | ----- |
| desktop |  <img width="800" alt="Screenshot 2023-08-28" src="https://github.com/dopex-io/elvarg/assets/85767768/0fefbe67-1062-4981-bc7a-57eb19b4752b"> |  <img width="801" alt="Screenshot 2023-08-28" src="https://github.com/dopex-io/elvarg/assets/85767768/97e37568-0fc5-4171-9ffa-a76299a1bb57"> |
| mobile  |        |       |

## How to Test

Expand the strike details in the option chain. Inspect via cmd/ctrl + shift + C and hover over items to confirm alignment.
