### PR TITLE
refactor:  move price chart to components/common

### DIFF
--- a/apps/dapp/src/components/common/PriceChart/index.tsx
+++ b/apps/dapp/src/components/common/PriceChart/index.tsx
@@ -80,9 +80,6 @@ const PriceChart = ({
     };
   }, [query]);
 
-  if (query.isFetched) {
-  }
-
   return (
     <div className={className}>
       {query.isFetched ? (

--- a/apps/dapp/src/components/common/PriceChart/index.tsx
+++ b/apps/dapp/src/components/common/PriceChart/index.tsx
@@ -3,11 +3,18 @@ import { useEffect, useRef } from 'react';
 import { Skeleton } from '@dopex-io/ui';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
+import cx from 'classnames';
 import { ColorType, createChart } from 'lightweight-charts';
 
 import { TOKEN_DATA } from 'constants/tokens';
 
-const PriceChart = ({ market }: { market: string }) => {
+const PriceChart = ({
+  market,
+  className = 'h-full w-full',
+}: {
+  market: string;
+  className?: string;
+}) => {
   const chartContainerRef = useRef<HTMLDivElement | null>(null);
 
   const query = useQuery({
@@ -26,7 +33,6 @@ const PriceChart = ({ market }: { market: string }) => {
     };
 
     const chart = createChart(chartContainerRef.current, {
-      height: 500,
       layout: {
         background: {
           type: ColorType.Solid,
@@ -74,11 +80,21 @@ const PriceChart = ({ market }: { market: string }) => {
     };
   }, [query]);
 
-  if (query.isFetching) {
-    return <Skeleton width={950} height={500} />;
+  if (query.isFetched) {
   }
 
-  return <div ref={chartContainerRef} className="m-3 rounded-xl h-full" />;
+  return (
+    <div className={className}>
+      {query.isFetched ? (
+        <div
+          ref={chartContainerRef}
+          className={cx('m-3 rounded-xl h-full w-full')}
+        />
+      ) : (
+        <Skeleton width={'100%'} height={'100%'} />
+      )}
+    </div>
+  );
 };
 
 export default PriceChart;

--- a/apps/dapp/src/pages/scalps/[poolName].tsx
+++ b/apps/dapp/src/pages/scalps/[poolName].tsx
@@ -10,6 +10,7 @@ import { NextSeo } from 'next-seo';
 import { useBoundStore } from 'store';
 
 import PageLayout from 'components/common/PageLayout';
+import PriceChart from 'components/common/PriceChart';
 import QuickLink from 'components/common/QuickLink';
 import Manage from 'components/scalps/Manage';
 import MigrationStepper from 'components/scalps/MigrationStepper';
@@ -17,7 +18,6 @@ import Orders from 'components/scalps/Orders';
 import Positions from 'components/scalps/Positions';
 import TopBar from 'components/scalps/TopBar';
 import TradeCard from 'components/scalps/TradeCard';
-import PriceChart from 'components/ssov-beta/PriceChart';
 
 import { CHAINS } from 'constants/chains';
 import seo from 'constants/seo';
@@ -134,9 +134,9 @@ const OptionScalps = ({ poolName }: { poolName: string }) => {
   return (
     <PageLayout>
       <TopBar />
-      <div className="flex flex-col space-y-2 lg:flex-row xl:space-x-4 justify-center">
+      <div className="flex flex-col space-y-2 lg:flex-row xl:space-x-4 justify-center h-full">
         <div className="flex flex-col w-full lg:w-3/4 space-y-4 h-full">
-          <PriceChart market={selectedPoolName} />
+          <PriceChart className="h-[520px]" market={selectedPoolName} />
           <Orders />
           <Positions />
         </div>

--- a/apps/dapp/src/pages/ssov-beta/[[...slug]].tsx
+++ b/apps/dapp/src/pages/ssov-beta/[[...slug]].tsx
@@ -6,9 +6,9 @@ import { NextSeo } from 'next-seo';
 import useVaultStore from 'hooks/ssov/useVaultStore';
 
 import PageLayout from 'components/common/PageLayout';
+import PriceChart from 'components/common/PriceChart';
 import AsidePanel from 'components/ssov-beta/AsidePanel';
 import InfoBox from 'components/ssov-beta/InfoBox';
-import PriceChart from 'components/ssov-beta/PriceChart';
 import Positions from 'components/ssov-beta/Tables/Positions';
 import StrikesChain from 'components/ssov-beta/Tables/StrikesChain';
 import TitleBar from 'components/ssov-beta/TitleBar';
@@ -85,9 +85,10 @@ const SsovBetaMarket = () => {
         />
         <div className="flex space-x-0 lg:space-x-6 flex-col sm:flex-col md:flex-col lg:flex-row space-y-3 md:space-y-0 justify-center">
           <div className="flex flex-col space-y-3 sm:w-full lg:w-3/4 h-full">
-            <div className="h-[520px] rounded-lg text-center flex flex-col justify-center text-stieglitz">
-              <PriceChart market={selectedMarket} />
-            </div>
+            <PriceChart
+              className="h-[520px] rounded-lg text-center flex flex-col justify-center text-stieglitz"
+              market={selectedMarket}
+            />
             <div className="space-y-4">
               <StrikesChain market={selectedMarket} />
               <Positions />


### PR DESCRIPTION
refactor: move price chart to components/common
fix: skeleton width

## Scope

Since price graph is being used in option scalps and ssov-beta, I've moved it to components/common assuming it will be used in other products as well. (currently implementing for straddles v3 ui)

## Screenshots

|         | before | after |
| ------- | ------ | ----- |
|  |     ![Screenshot 2023-08-29 at 3 36 46 PM](https://github.com/dopex-io/elvarg/assets/90272722/0e759025-fe73-4efb-8969-f756e26f2dfd)   |  ![Screenshot 2023-08-29 at 3 39 03 PM](https://github.com/dopex-io/elvarg/assets/90272722/c0cc7f78-355f-4004-89ff-c3e3af881543)     |





