### PR TITLE
fix: option scalp limit orders (DOP-481)

### DIFF
--- a/apps/dapp/src/components/scalps/TradeCard/index.tsx
+++ b/apps/dapp/src/components/scalps/TradeCard/index.tsx
@@ -146,7 +146,7 @@ const TradeCard = () => {
 
     let tick = Math.round(Math.log(_markPrice) / Math.log(1.0001) / 10) * 10;
 
-    tick += isShort ? 10 : -10;
+    tick += isShort ? 20 : -20;
 
     return (1.0001 ** tick).toFixed(4);
   }, [optionScalpData, isShort]);
@@ -422,26 +422,11 @@ const TradeCard = () => {
       }
     } else if (orderType === 'Limit') {
       try {
-        let limitPrice;
-
-        if (rawLimitPrice === '') {
-          limitPrice =
-            Number(
-              utils.formatUnits(
-                markPrice,
-                optionScalpData?.quoteDecimals?.toNumber()!,
-              ),
-            ) *
-            10 **
-              (optionScalpData?.quoteDecimals?.toNumber() -
-                optionScalpData?.baseDecimals?.toNumber());
-        } else {
-          limitPrice =
-            Number(rawLimitPrice) *
-            10 **
-              (optionScalpData?.quoteDecimals?.toNumber() -
-                optionScalpData?.baseDecimals?.toNumber());
-        }
+        const limitPrice =
+          Number(rawLimitPrice) *
+          10 **
+            (optionScalpData?.quoteDecimals?.toNumber() -
+              optionScalpData?.baseDecimals?.toNumber());
 
         const spacing = 10;
 
@@ -536,6 +521,10 @@ const TradeCard = () => {
 
   const handleOrderTypeToggle = useCallback(() => {
     setOrderType(orderType === 'Market' ? 'Limit' : 'Market');
+  }, [setOrderType]);
+
+  useEffect(() => {
+    setMaximumTick();
   }, [orderType]);
 
   const setSelectedMargin = useCallback(
@@ -662,14 +651,7 @@ const TradeCard = () => {
             </p>
             <Input
               color="cod-gray"
-              placeholder={String(
-                Number(
-                  utils.formatUnits(
-                    markPrice,
-                    optionScalpData?.quoteDecimals?.toNumber()!,
-                  ),
-                ),
-              )}
+              placeholder={rawLimitPrice}
               value={rawLimitPrice}
               onChange={(e: {
                 target: { value: React.SetStateAction<string | number> };

--- a/apps/dapp/src/components/scalps/TradeCard/index.tsx
+++ b/apps/dapp/src/components/scalps/TradeCard/index.tsx
@@ -422,11 +422,26 @@ const TradeCard = () => {
       }
     } else if (orderType === 'Limit') {
       try {
-        const limitPrice =
-          Number(rawLimitPrice) *
-          10 **
-            (optionScalpData?.quoteDecimals?.toNumber() -
-              optionScalpData?.baseDecimals!.toNumber());
+        let limitPrice;
+
+        if (rawLimitPrice === '') {
+          limitPrice =
+            Number(
+              utils.formatUnits(
+                markPrice,
+                optionScalpData?.quoteDecimals?.toNumber()!,
+              ),
+            ) *
+            10 **
+              (optionScalpData?.quoteDecimals?.toNumber() -
+                optionScalpData?.baseDecimals?.toNumber());
+        } else {
+          limitPrice =
+            Number(rawLimitPrice) *
+            10 **
+              (optionScalpData?.quoteDecimals?.toNumber() -
+                optionScalpData?.baseDecimals?.toNumber());
+        }
 
         const spacing = 10;
 
@@ -582,7 +597,7 @@ const TradeCard = () => {
   return (
     <div className="flex flex-col space-y-4 bg-cod-gray rounded-b-md">
       <div className="flex items-center justify-end p-2 pb-0">
-        <p className="text-xs text-stieglitz">Open with a limit order</p>
+        <p className="text-xs text-stieglitz mr-2">Open with a limit order</p>
         <Checkbox
           // @ts-ignore
           size="xs"


### PR DESCRIPTION
## Scope

[closes issue-481](https://linear.app/dopex/issue/DOP-481/option-scalp-limit-orders)

## Implementation

When a user toggles the limit order checkbox rawLimitPrice is now automatically updated to the nearest tick, this avoid to show an error if the user clicks Open trade without changing the tick

## How to Test

Open demo link
