### PR TITLE
fix: bonds table button bug

### DIFF
--- a/apps/dapp/src/components/rdpx-v2/AsidePanel/alerts.ts
+++ b/apps/dapp/src/components/rdpx-v2/AsidePanel/alerts.ts
@@ -40,8 +40,10 @@ const alerts: Record<string, AlertType> = {
   defaultDelegate: {
     label: 'Delegate',
     header: 'What does delegating do?',
-    body: `Provide only WETH as collateral to receive 75% share + fee of the bonds minted by another user who bonds with only rDPX. 
-          Delegated collateral with lower fee is utilized first.`,
+    body: `Provide only WETH as collateral to receive 75% share + fee of the bond minted by another user 
+          who bonds with only rDPX. Delegated collateral with lower fee is utilized first. The bond generated 
+          from delegated WETH don't vest linearly, and will be redeemable only post-maturation. A protocol fee 
+          of 2% is discounted from the value of the bond.`,
     severity: AlertSeverity.info,
     disabled: true,
   },

--- a/apps/dapp/src/components/rdpx-v2/Tables/UserBonds.tsx
+++ b/apps/dapp/src/components/rdpx-v2/Tables/UserBonds.tsx
@@ -79,19 +79,19 @@ const UserBonds = () => {
       timestamp: bond.timestamp,
       positionId: BigInt(bond.positionId),
       vestedAmount:
-        bond.maturity * 1000n > BigInt(new Date().getTime()) ? bond.amount : 0n,
+        bond.maturity * 1000n > BigInt(new Date().getTime()) ? 0n : bond.amount,
       claimableBalance: 0n,
     }));
 
     return userBonds.concat(formattedDelegateBonds).map((bond) => {
       let label = 'Claim';
-      if (bond.positionId) {
+      if (bond.positionId > -1) {
         label = 'Redeem';
       }
 
       const handleRedeem = () => {
-        if (!bond.positionId) handleVest(bond.id);
-        else redeemDelegateBond(bond.positionId);
+        if (bond.positionId === -1n) handleVest(bond.id);
+        else redeemDelegateBond(BigInt(bond.positionId));
       };
 
       return {
@@ -106,7 +106,9 @@ const UserBonds = () => {
         button: {
           label: label,
           id: bond.id,
-          disabled: !!bond.positionId, // todo: enable 5-day post-maturity of DelegationControllerV1
+          disabled:
+            bond.maturity * 1000n < BigInt(new Date().getTime()) ||
+            bond.positionId !== -1n, // enable if either bond has matured or bond is vested
           action: handleRedeem,
         },
       };

--- a/apps/dapp/src/hooks/rdpx/useRdpxV2CoreData.ts
+++ b/apps/dapp/src/hooks/rdpx/useRdpxV2CoreData.ts
@@ -46,7 +46,7 @@ export interface UserBond {
   id: bigint;
   vestedAmount: bigint;
   claimableBalance: bigint;
-  positionId?: bigint;
+  positionId: bigint;
 }
 
 export interface DelegatePosition {
@@ -232,7 +232,7 @@ const useRdpxV2CoreData = ({ user = '0x' }: Props) => {
     }
     let userBonds = await Promise.all(multicallAggregate);
 
-    const _userBonds = userBonds.map((bond, i) => {
+    const _userBonds: UserBond[] = userBonds.map((bond, i) => {
       const rate =
         (bond[0] * parseUnits('1', DECIMALS_STRIKE)) / (bond[1] - bond[2]);
 
@@ -254,6 +254,7 @@ const useRdpxV2CoreData = ({ user = '0x' }: Props) => {
         timestamp: bond[2],
         vestedAmount,
         claimableBalance,
+        positionId: -1n,
       };
     });
 


### PR DESCRIPTION
Newly introduced bug with PR #781. The buttons in bonds table were incorrectly displaying vested amounts and the buttons for delegate bonds were enabled even though not matured. 