### PR TITLE
fix: show call symbol for trade

### DIFF
--- a/apps/dapp/src/components/clamm/AsidePanel/components/SelectedStrikeItem/index.tsx
+++ b/apps/dapp/src/components/clamm/AsidePanel/components/SelectedStrikeItem/index.tsx
@@ -426,7 +426,13 @@ const SelectedStrikeItem = ({
             value={editAllMode ? commonInputAmount : inputAmount}
             type="number"
             min="0"
-            placeholder={`0.0 ${strikeData.tokenSymbol}`}
+            placeholder={`0.0 ${
+              isTrade
+                ? selectedOptionsPool
+                  ? selectedOptionsPool.callToken.symbol
+                  : '-'
+                : strikeData.tokenSymbol
+            }`}
             className={cn(
               'w-full text-[13px] text-left bg-umbra focus:outline-none focus:border-mineshaft rounded-md placeholder-mineshaft',
               disabledInput ? 'text-stieglitz' : 'text-white',


### PR DESCRIPTION
When buying options, input place holder will now show call token symbol for puts and calls instead of the call or put token symbol.

Before: 
![image](https://github.com/dopex-io/elvarg/assets/90272722/6535e818-2e4f-45ea-bd33-1b71c4a08037)


After:
![image](https://github.com/dopex-io/elvarg/assets/90272722/9d09f4dc-d0ff-4b81-b207-c13d42ed30e9)
