### PR TITLE
fix: positions summary decimals

### DIFF
--- a/apps/dapp/src/components/clamm/PositionsTable/components/Positions/BuyPositions/components/PositionSummary/index.tsx
+++ b/apps/dapp/src/components/clamm/PositionsTable/components/Positions/BuyPositions/components/PositionSummary/index.tsx
@@ -22,7 +22,7 @@ const PositionSummary = ({
         <span className="text-xs flex items-center justify-center space-x-[2px]">
           <span className="text-stieglitz">$</span>
           <span className={cn(totalProfitUsd > 0 && 'text-up-only')}>
-            {formatAmount(totalProfitUsd, 3)}
+            {formatAmount(totalProfitUsd, 5)}
           </span>
         </span>
       </div>
@@ -30,13 +30,13 @@ const PositionSummary = ({
         <span className="text-stieglitz text-xs">Total premium:</span>
         <span className="text-xs flex items-center justify-center space-x-[2px]">
           <span className="text-stieglitz">$</span>
-          <span>{formatAmount(totalPremiumUsd, 3)}</span>
+          <span>{formatAmount(totalPremiumUsd, 5)}</span>
         </span>
       </div>
       <div className="flex items-center justify-center space-x-[4px]">
         <span className="text-stieglitz text-xs">Total size:</span>
         <span className="text-xs flex items-center justify-center space-x-[4px]">
-          <span>{formatAmount(totalOptions, 3)}</span>
+          <span>{formatAmount(totalOptions, 5)}</span>
           <span className="text-stieglitz text-xs">{callTokenSymbol}</span>
         </span>
       </div>

--- a/apps/dapp/src/components/clamm/PositionsTable/components/Positions/LPPositions/components/PositionSummary/index.tsx
+++ b/apps/dapp/src/components/clamm/PositionsTable/components/Positions/LPPositions/components/PositionSummary/index.tsx
@@ -28,7 +28,7 @@ const PositionsSummary = ({
         <span className="text-xs flex items-center justify-center space-x-[2px]">
           <span className="text-stieglitz">$</span>
           <span className={cn(Number(totalEarned) > 0 && 'text-up-only')}>
-            {formatAmount(totalEarned, 3)}
+            {formatAmount(totalEarned, 5)}
           </span>
         </span>
       </div>
@@ -36,19 +36,19 @@ const PositionsSummary = ({
         <span className="text-stieglitz text-xs">Total deposit:</span>
         <span className="text-xs flex items-center justify-center space-x-[2px]">
           <span className="text-stieglitz">$</span>
-          <span>{formatAmount(totalDeposit, 3)}</span>
+          <span>{formatAmount(totalDeposit, 5)}</span>
         </span>
       </div>
       <div className="flex items-center justify-center space-x-[6px]">
         <span className="text-stieglitz text-xs">Total withdrawable:</span>
         <span className="text-xs flex items-center justify-center space-x-[2px]">
-          <span>{formatAmount(totalWithdrawable.token0.amount, 3)}</span>
+          <span>{formatAmount(totalWithdrawable.token0.amount, 5)}</span>
           <span className="text-stieglitz">
             {totalWithdrawable.token0.symbol}
           </span>
         </span>
         <span className="text-xs flex items-center justify-center space-x-[2px]">
-          <span>{formatAmount(totalWithdrawable.token1.amount, 3)}</span>
+          <span>{formatAmount(totalWithdrawable.token1.amount, 5)}</span>
           <span className="text-stieglitz">
             {totalWithdrawable.token1.symbol}
           </span>

--- a/apps/dapp/src/utils/general/formatAmount.ts
+++ b/apps/dapp/src/utils/general/formatAmount.ts
@@ -5,6 +5,7 @@ function formatAmount(
   showDash: boolean = false,
 ): string {
   const typecastedAmount = Math.abs(Number(amount));
+  if (typecastedAmount === 0) return '0';
   const isNeg = Number(amount) < 0;
   let result;
 


### PR DESCRIPTION
scope:
Increase decimals of details in positions summary and let formatAmount util fn return 0 if the value input to it is 0

before:

![image](https://github.com/dopex-io/elvarg/assets/90272722/c26f5330-90af-48ea-811c-3521d54dd18a)

after:
![image](https://github.com/dopex-io/elvarg/assets/90272722/5c428f71-8109-4269-8a2a-a351ce54ce19)


