### PR TITLE
fix(clamm): spilling position summary in smaller viewports (eng-640)

### DIFF
--- a/apps/dapp/src/components/clamm/PositionsTable/components/Positions/BuyPositions/components/PositionSummary/index.tsx
+++ b/apps/dapp/src/components/clamm/PositionsTable/components/Positions/BuyPositions/components/PositionSummary/index.tsx
@@ -16,26 +16,26 @@ const PositionSummary = ({
   totalProfitUsd,
 }: Props) => {
   return (
-    <div className="flex items-center space-x-[6px]">
-      <div className="flex items-center justify-center space-x-[4px]">
+    <div className="flex flex-col md:flex-row items-left md:items-center space-x-0 space-y-1.5 md:space-y-0 md:space-x-1.5">
+      <div className="flex items-center space-x-1">
         <span className="text-stieglitz text-xs">Total profit:</span>
-        <span className="text-xs flex items-center justify-center space-x-[2px]">
+        <span className="text-xs flex items-center space-x-0.5">
           <span className="text-stieglitz">$</span>
           <span className={cn(totalProfitUsd > 0 && 'text-up-only')}>
             {formatAmount(totalProfitUsd, 5)}
           </span>
         </span>
       </div>
-      <div className="flex items-center justify-center space-x-[4px]">
+      <div className="flex items-center space-x-1">
         <span className="text-stieglitz text-xs">Total premium:</span>
-        <span className="text-xs flex items-center justify-center space-x-[2px]">
+        <span className="text-xs flex items-center space-x-0.5">
           <span className="text-stieglitz">$</span>
           <span>{formatAmount(totalPremiumUsd, 5)}</span>
         </span>
       </div>
-      <div className="flex items-center justify-center space-x-[4px]">
+      <div className="flex items-center space-x-1">
         <span className="text-stieglitz text-xs">Total size:</span>
-        <span className="text-xs flex items-center justify-center space-x-[4px]">
+        <span className="text-xs flex items-center space-x-0.5">
           <span>{formatAmount(totalOptions, 5)}</span>
           <span className="text-stieglitz text-xs">{callTokenSymbol}</span>
         </span>

--- a/apps/dapp/src/components/clamm/PositionsTable/components/Positions/BuyPositions/index.tsx
+++ b/apps/dapp/src/components/clamm/PositionsTable/components/Positions/BuyPositions/index.tsx
@@ -412,7 +412,7 @@ const BuyPositions = ({
   }, [setBuyPositionsLength, positions.length]);
 
   return (
-    <div className="w-full flex flex-col space-y-3 p-1">
+    <div className="w-full flex flex-col space-y-3 p-3">
       <div className="bg-cod-gray flex items-center justify-between space-x-3">
         <PositionSummary
           callTokenSymbol={selectedOptionsMarket?.callToken.symbol ?? '-'}

--- a/apps/dapp/src/components/clamm/PositionsTable/components/Positions/BuyPositions/index.tsx
+++ b/apps/dapp/src/components/clamm/PositionsTable/components/Positions/BuyPositions/index.tsx
@@ -7,12 +7,14 @@ import React, {
 } from 'react';
 import { Address, formatUnits, getAddress, Hex } from 'viem';
 
+import { Button } from '@dopex-io/ui';
 import {
   ArrowDownRightIcon,
   ArrowPathIcon,
   ArrowUpRightIcon,
 } from '@heroicons/react/24/solid';
 import { useQuery } from '@tanstack/react-query';
+import { noop } from 'lodash';
 import toast from 'react-hot-toast';
 import { useNetwork, useWalletClient } from 'wagmi';
 
@@ -410,26 +412,30 @@ const BuyPositions = ({
   }, [setBuyPositionsLength, positions.length]);
 
   return (
-    <div className="w-full flex flex-col space-y-[12px] py-[12px]">
-      <div className="bg-cod-gray flex px-[12px] items-center justify-between space-x-[12px]">
+    <div className="w-full flex flex-col space-y-3 p-1">
+      <div className="bg-cod-gray flex items-center justify-between space-x-3">
         <PositionSummary
           callTokenSymbol={selectedOptionsMarket?.callToken.symbol ?? '-'}
           totalOptions={optionsSummary.totalOptions}
           totalPremiumUsd={optionsSummary.totalPremiumUsd}
           totalProfitUsd={optionsSummary.totalProfitUsd}
         />
-        <div className="flex items-center space-x-[6px]">
-          <div className="h-fit w-fit p-[2px] bg-mineshaft rounded-md">
+        <div className="flex space-x-1.5 md:self-center self-start">
+          <Button
+            size="xsmall"
+            color="mineshaft"
+            className="hover:text-white"
+            onClick={isRefetching ? noop : handleRefresh}
+          >
             <ArrowPathIcon
-              height={22}
-              width={22}
-              onClick={isRefetching ? () => {} : handleRefresh}
+              height={16}
+              width={16}
               className={cn(
-                'bg-mineshaft text-stieglitz p-[2px] hover:text-white cursor-pointer',
+                'bg-mineshaft text-white p-0.5',
                 isRefetching && 'animate-spin cursor-progress',
               )}
             />
-          </div>
+          </Button>
           <MultiExerciseButton positions={selectedOptions} />
         </div>
       </div>


### PR DESCRIPTION
Fix spilling position summary inside the Buy Positions table. See the Images attached below.

## Scope

A core component of the clamm UI is not responsive in smaller viewports and spills over the table as seen in the image below. This PR aims to resolve this issue.

[closes issue-640](https://linear.app/stryke/issue/ENG-640/fix-position-summary-ui-in-smaller-viewports-in-clamm-ui)

## Implementation

Add appropriate tailwind classes for different css breakpoints

## Screenshots

|         | before | after |
| ------- | ------ | ----- |
| desktop |  <img width="1233" alt="Screenshot 2024-03-14" src="https://github.com/dopex-io/elvarg/assets/85767768/276f62a7-059f-43a3-b2ac-b96014a24ae4">  |  <img width="1208" alt="Screenshot 2024-03-14" src="https://github.com/dopex-io/elvarg/assets/85767768/89aabf9e-9fc3-4b1c-894d-55b932d5a2b0"> |
| mobile  |  <img width="427" alt="Screenshot 2024-03-14" src="https://github.com/dopex-io/elvarg/assets/85767768/95b0d218-9552-45a9-ae0d-f3ab50f61431">  |    <img width="410" alt="Screenshot 2024-03-14" src="https://github.com/dopex-io/elvarg/assets/85767768/8bf31593-d39d-4bd7-9b6b-27ce11ca7855">   |

## How to Test

- Make sure nothing from the existing implementation is breaking with this responsive UI addition. Compare this PR and the current version across different viewport sizes to test this.